### PR TITLE
fix(run.py): Using `safe_load` inside `load`

### DIFF
--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ class Run:
     def _ignoreSet(self):
         ignore_tests = []
         with open(self._ignoreFile()) as f:
-            content = yaml.load(f)
+            content = yaml.safe_load(f)
             ignore_tests.extend(content['tests'])
         return set(ignore_tests)
 


### PR DESCRIPTION
Fix this issue
```
04:06:53  Traceback (most recent call last):
04:06:53    File "main.py", line 39, in <module>
04:06:53      main(arguments.java_driver_git, arguments.scylla_install_dir, arguments.tests, versions, arguments.scylla_version)
04:06:53    File "main.py", line 14, in main
04:06:53      results.append(run.Run(java_driver_git, scylla_install_dir, version, tests, scylla_version=scylla_version))
04:06:53    File "/data/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/run.py", line 14, in __init__
04:06:53      self._run()
04:06:53    File "/data/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/run.py", line 58, in _run
04:06:53      for ignore_element in self._ignoreSet():
04:06:53    File "/data/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/run.py", line 31, in _ignoreSet
04:06:53      content = yaml.load(f)
04:06:53  TypeError: load() missing 1 required positional argument: 'Loader'
```