### PR TITLE
Ignore jmx base test, since ccm uses diffrent address for jmx

### DIFF
--- a/versions/scylla/3.10.2.1/ignore.yaml
+++ b/versions/scylla/3.10.2.1/ignore.yaml
@@ -114,3 +114,6 @@ tests:
   - ConsistencyTest
   - ExceptionsScassandraTest
   - SpeculativeExecutionTest
+
+  # disable cause now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest

--- a/versions/scylla/3.7.1.0/ignore.yaml
+++ b/versions/scylla/3.7.1.0/ignore.yaml
@@ -114,3 +114,6 @@ tests:
   - ConsistencyTest
   - ExceptionsScassandraTest
   - SpeculativeExecutionTest
+
+  # disable cause now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest


### PR DESCRIPTION
Ref: https://github.com/scylladb/scylla-ccm/pull/393