### PR TITLE
Skip BoundStatementCcmIT.should_set_all_occurrences_of_variable

### DIFF
--- a/versions/datastax/4.12.0/ignore.yaml
+++ b/versions/datastax/4.12.0/ignore.yaml
@@ -136,3 +136,5 @@ tests:
     # java.util.NoSuchElementException: No value present
     - SchemaIT#should_get_virtual_metadata
     - SchemaIT#should_exclude_virtual_keyspaces_from_token_map
+    # skipping cause of https://github.com/scylladb/scylla/issues/10956
+    - BoundStatementCcmIT#should_set_all_occurrences_of_variable

--- a/versions/datastax/4.12.1/ignore.yaml
+++ b/versions/datastax/4.12.1/ignore.yaml
@@ -138,3 +138,6 @@ tests:
     - SchemaIT#should_exclude_virtual_keyspaces_from_token_map
 
     - NettyResourceLeakDetectionIT#should_not_leak_compressed_lz4
+
+    # skipping cause of https://github.com/scylladb/scylla/issues/10956
+    - BoundStatementCcmIT#should_set_all_occurrences_of_variable

--- a/versions/datastax/4.13.0/ignore.yaml
+++ b/versions/datastax/4.13.0/ignore.yaml
@@ -136,3 +136,5 @@ tests:
     # java.util.NoSuchElementException: No value present
     - SchemaIT#should_get_virtual_metadata
     - SchemaIT#should_exclude_virtual_keyspaces_from_token_map
+    # skipping cause of https://github.com/scylladb/scylla/issues/10956
+    - BoundStatementCcmIT#should_set_all_occurrences_of_variable


### PR DESCRIPTION
since a recent fix in scylla make this test irelevent,
it was decided to skip this test from now on

Close: https://github.com/scylladb/scylla/issues/10956