### PR TITLE
Remove _JAVA_OPTIONS env variable

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -122,14 +122,12 @@ docker_cmd="docker run --detach=true \
     -v ${SCYLLA_JAVA_DRIVER_MATRIX_DIR}:${SCYLLA_JAVA_DRIVER_MATRIX_DIR} \
     -e HOME \
     -e SCYLLA_EXT_OPTS \
-    -e LC_ALL=en_US.UTF-8 \
     -e NODE_TOTAL \
     -e NODE_INDEX \
     -e WORKSPACE \
     ${BUILD_OPTIONS} \
     ${JOB_OPTIONS} \
     ${AWS_OPTIONS} \
-    -e _JAVA_OPTIONS=-Duser.home=$HOME \
     -w ${SCYLLA_JAVA_DRIVER_MATRIX_DIR} \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \


### PR DESCRIPTION
seems like now that we use unifed package, we are failing the java version check case of a warning, that break the `install.sh` code:

```
java -version
Picked up _JAVA_OPTIONS: -Duser.home=/home/fruch
openjdk version "1.8.0_322"
OpenJDK Runtime Environment (build 1.8.0_322-8u322-b06-1~deb9u1-b06)
OpenJDK 64-Bit Server VM (build 25.322-b06, mixed mode)
```

so we are removing those flags, seems like they aren't needed anymore.