### PR TITLE
datastax: Ignore com.datastax.oss.driver.core.cql.NowInSecondsIT

### DIFF
--- a/versions/datastax/4.17.0/ignore.yaml
+++ b/versions/datastax/4.17.0/ignore.yaml
@@ -138,3 +138,6 @@ tests:
     - SchemaIT#should_exclude_virtual_keyspaces_from_token_map
     # skipping cause of https://github.com/scylladb/scylla/issues/10956
     - BoundStatementCcmIT#should_set_all_occurrences_of_variable
+    # Can't use nowInSeconds with protocol V4
+    - NowInSecondsIT
+


### PR DESCRIPTION
This test fails on protocol v4 with: `Can't use nowInSeconds with
protocol V4`.

Fixes #27 