### PR TITLE
run_test.sh: Mount /tmp into the unit test container

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -147,6 +147,7 @@ docker_cmd="docker run --init --detach=true \
     -v ${HOME}/.local:${HOME}/.local \
     -v ${HOME}/.ccm:${HOME}/.ccm \
     -v ${HOME}/.m2:${HOME}/.m2 \
+    -v "/tmp":"/tmp" \
     --tmpfs ${HOME}/.config \
     --network=host --privileged \
     ${DOCKER_IMAGE} bash -c 'pip install --user -e ${CCM_DIR} ;  export PATH=\$PATH:\${HOME}/.local/bin; $*'"


### PR DESCRIPTION
This change fixes an issue where tests would try to share configuration
with child containers via /tmp, but since those directories are not mounted and
a parent docker socket is used the containers created this way would
receive incorrect mounts. This fixes issues with SniProxy tests.

Fixes #28
