### PR TITLE
datastax: add patch for 4.18.0

### DIFF
--- a/versions/datastax/4.18.0/ignore.yaml
+++ b/versions/datastax/4.18.0/ignore.yaml
@@ -1,0 +1,143 @@
+tests:
+    # Unsupported CUSTOM INDEX class org.apache.cassandra.index.sasi.SASIIndex. Note that currently, Scylla does not support SASI or any other CUSTOM INDEX class.
+    - DeleteIT
+    - InsertIT
+    - GetEntityIT
+    - UpdateIT
+    - SelectCustomWhereClauseIT
+    - SelectIT
+    - SetEntityIT
+    - UpdateCustomIfClauseIT
+    - CustomResultTypeIT
+    - DeleteReactiveIT
+    - FluentEntityIT
+    - ImmutableEntityIT
+    - InsertReactiveIT
+    - SchemaValidationIT
+    - SelectReactiveIT
+    - UpdateReactiveIT
+
+    # ServerError: Not implemented: LWT
+    - QueryReturnTypesIT#should_execute_conditional_query_and_map_to_boolean
+    - QueryReturnTypesIT#should_execute_async_conditional_query_and_map_to_boolean
+    - BatchStatementIT#should_execute_cas_batch
+    - PreparedStatementIT#should_not_store_metadata_for_conditional_updates_in_legacy_protocol
+
+    # java isn't supported for scylla user defined functions and aggregations
+    - SchemaChangesIT#should_handle_aggregate_creation
+    - SchemaChangesIT#should_handle_aggregate_drop
+    - SchemaChangesIT#should_handle_aggregate_update
+    - SchemaChangesIT#should_handle_function_creation
+    - SchemaChangesIT#should_handle_function_drop
+    - SchemaChangesIT#should_handle_function_update
+
+    # Unknown property 'additional_write_policy'
+    - DescribeIT
+
+    # wrong case of NULL is returned in schema of MV
+    - SchemaChangesIT#should_handle_view_creation
+
+    # RandomPartitioner isn't supported by scylla anymore
+    - RandomTokenIT
+    - RandomTokenVnodesIT
+
+    # ByteOrderedPartitioner isn't supported by scylla anymore
+    - ByteOrderedTokenVnodesIT
+    - ByteOrderedTokenIT
+
+    # InvalidQueryException: Unknown type ks_17.address
+    - CaseSensitiveUdtIT#should_expose_metadata_with_correct_case
+
+    # ServerError: Can't find a column family with UUID 963ec1e0-1771-11ea-8115-000000000000
+    - CaseSensitiveUdtIT
+
+    # init query OPTIONS: unexpected server error [PROTOCOL_ERROR] Unknown compression algorithm)
+    - DirectCompressionIT#should_execute_queries_with_lz4_compression
+    - DirectCompressionIT#should_execute_queries_with_snappy_compression
+    - HeapCompressionIT#should_execute_queries_with_lz4_compression
+    - HeapCompressionIT#should_execute_queries_with_snappy_compression
+
+    # Cannot run program "*/java-driver/integration-tests/run.sh" (in directory "*/java-driver/integration-tests"): error=2, No such file or directory
+    - CloudIT
+
+    # ssl issue - init query OPTIONS: error writing )
+    - DefaultSslEngineFactoryIT
+    - DefaultSslEngineFactoryPropertyBasedWithClientAuthIT
+    - DefaultSslEngineFactoryWithClientAuthIT
+    - DefaultSslEngineFactoryHostnameValidationIT
+    - ProgrammaticSslIT
+    - DefaultSslEngineFactoryPropertyBasedIT
+
+    # error: unrecognised option '-Dcassandra.superuser_setup_delay_ms=0'
+    - PlainTextAuthProviderIT
+
+    # I don't know if scylla has the same thing for warnings, i.e. noticeable by the driver
+    - ExecutionInfoWarningsIT
+
+    # weird errors, would need to investigate further
+    - OsgiIT
+    - OsgiLz4IT
+    - OsgiShadedIT
+    - OsgiSnappyIT
+    - OsgiCustomLoadBalancingPolicyIT
+
+    # https://github.com/scylladb/scylla/issues/10008, scylla can return empty page, this test isn't expecting
+    - SelectOtherClausesIT#should_select_with_per_partition_limit
+
+    # pause/resume scylla doesn't immediately have schema disagreement
+    - SchemaAgreementIT#should_fail_on_timeout
+
+    # expecting scylla to report 3.11.0 as CQL version, scylla report 3.0.8 for now
+    - NodeMetadataIT#should_expose_node_metadata
+
+    # NodeStateListener isn't called with onRemove when node decommissioned
+    - RemovedNodeIT#should_signal_and_destroy_pool_when_node_gets_removed
+    # Scylla doesn't support customPayload in CQL
+    - BoundStatementCcmIT#should_propagate_attributes_when_preparing_a_simple_statement
+
+    # test wrongly assume all nodes are on 127.0.0.1 except node5 from dc2
+    - DefaultLoadBalancingPolicyIT#should_apply_node_filter
+
+    - AddedNodeIT#should_signal_and_create_pool_when_node_gets_added
+
+    # scylla doesn't support protocol v5 yet
+    - ProtocolVersionInitialNegotiationIT#should_downgrade_to_v5_oss
+    - ProtocolVersionInitialNegotiationIT#should_not_downgrade_if_server_supports_latest_version_oss
+    - ProtocolVersionInitialNegotiationIT#should_use_explicitly_provided_v5_oss
+
+    - PreparedStatementIT#should_not_store_metadata_for_conditional_updates
+    - PreparedStatementIT#should_update_metadata_when_schema_changed_across_executions
+    - PreparedStatementIT#should_update_metadata_when_schema_changed_across_sessions
+
+    - DefaultReactiveResultSetIT#should_write_batch_cas
+    - DefaultReactiveResultSetIT#should_write_cas
+
+    - DriverExecutionProfileReloadIT
+    - SessionLeakIT#should_warn_when_session_count_exceeds_threshold
+
+    # expected "Undefined column name d" and got "Undefined name d"
+    - PreparedStatementIT#should_fail_to_reprepare_if_query_becomes_invalid
+
+    - PreparedStatementIT#should_not_store_metadata_for_conditional_updates
+    - PreparedStatementIT#should_update_metadata_when_schema_changed_across_executions
+    - PreparedStatementIT#should_update_metadata_when_schema_changed_across_sessions
+    -
+    # java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4
+    - PerRequestKeyspaceIT#hould_execute_batch_with_explicit_keyspace
+    - PerRequestKeyspaceIT#should_execute_batch_with_inferred_keyspace
+    - PerRequestKeyspaceIT#should_execute_simple_statement_with_keyspace
+    - PerRequestKeyspaceIT#should_prepare_statement_with_keyspace
+    - PerRequestKeyspaceIT#should_reprepare_statement_with_keyspace_on_the_fly
+    - PreparedStatementIT#should_update_metadata_when_schema_changed_across_pages
+    - PerRequestKeyspaceIT#should_execute_batch_with_explicit_keyspace
+
+    # Undefined name coordinator_port in selection clause
+    - QueryTraceIT#should_fetch_trace_when_tracing_enabled
+    # java.util.NoSuchElementException: No value present
+    - SchemaIT#should_get_virtual_metadata
+    - SchemaIT#should_exclude_virtual_keyspaces_from_token_map
+    # skipping cause of https://github.com/scylladb/scylla/issues/10956
+    - BoundStatementCcmIT#should_set_all_occurrences_of_variable
+    # Can't use nowInSeconds with protocol V4
+    - NowInSecondsIT
+

--- a/versions/datastax/4.18.0/patch
+++ b/versions/datastax/4.18.0/patch
@@ -1,0 +1,302 @@
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+index 32e8c3929..292a8dfa5 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+@@ -58,7 +58,7 @@ public class NodeMetadataIT {
+                   assertThat(broadcastAddress.getAddress()).isEqualTo(connectAddress.getAddress()));
+       assertThat(node.getListenAddress().get().getAddress()).isEqualTo(connectAddress.getAddress());
+       assertThat(node.getDatacenter()).isEqualTo("dc1");
+-      assertThat(node.getRack()).isEqualTo("r1");
++      assertThat(node.getRack()).isEqualTo("RAC1");
+       if (!CcmBridge.DSE_ENABLEMENT) {
+         // CcmBridge does not report accurate C* versions for DSE, only approximated values
+         assertThat(node.getCassandraVersion()).isEqualTo(ccmRule.getCassandraVersion());
+diff --git a/test-infra/revapi.json b/test-infra/revapi.json
+index 3cfbc8b53..0fa33a041 100644
+--- a/test-infra/revapi.json
++++ b/test-infra/revapi.json
+@@ -171,6 +171,16 @@
+         "code": "java.method.removed",
+         "old": "method void com.datastax.oss.driver.api.testinfra.ccm.CcmRule::reloadCore(int, java.lang.String, java.lang.String, boolean)",
+         "justification": "Modifying the state of a globally shared CCM instance is dangerous"
++      },
++      {
++        "code": "java.method.removed",
++        "old": "method com.datastax.oss.driver.api.testinfra.ccm.CcmBridge.Builder com.datastax.oss.driver.api.testinfra.ccm.CcmBridge.Builder::withIpPrefix(java.lang.String)",
++        "justification": "Scylla CCM support"
++      },
++      {
++        "code": "java.method.removed",
++        "old": "method com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule.Builder com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule.Builder::withIpPrefix(java.lang.String)",
++        "justification": "Scylla CCM support"
+       }
+     ]
+   }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+index d4830dd24..bce89823d 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+@@ -18,11 +18,18 @@ package com.datastax.oss.driver.api.testinfra.ccm;
+ import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+ import com.datastax.oss.driver.api.core.ProtocolVersion;
+ import com.datastax.oss.driver.api.core.Version;
++import com.datastax.oss.driver.api.core.metadata.EndPoint;
+ import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
+ import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
+ import com.datastax.oss.driver.api.testinfra.requirement.VersionRequirement;
++import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
++
++import java.net.InetSocketAddress;
+ import java.util.Collection;
++import java.util.Collections;
+ import java.util.Optional;
++import java.util.Set;
++
+ import org.junit.AssumptionViolatedException;
+ import org.junit.runner.Description;
+ import org.junit.runners.model.Statement;
+@@ -56,6 +63,13 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
+     ccmBridge.remove();
+   }
+ 
++  @Override
++  public Set<EndPoint> getContactPoints() {
++    return Collections.singleton(
++        new DefaultEndPoint(
++            new InetSocketAddress(String.format("127.0.%s.1", ccmBridge.idPrefix), 9042)));
++  }
++
+   @Override
+   public Statement apply(Statement base, Description description) {
+     BackendType backend =
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+index cef9e13c4..054c1e78e 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+@@ -54,6 +54,10 @@ public class CcmBridge implements AutoCloseable {
+   public static final Version VERSION =
+       Objects.requireNonNull(Version.parse(System.getProperty("ccm.version", "4.0.0")));
+ 
++  public String idPrefix = "0";
++
++  public static final String SCYLLA_VERSION = System.getProperty("scylla.version");
++
+   public static final String INSTALL_DIRECTORY = System.getProperty("ccm.directory");
+ 
+   public static final String BRANCH = System.getProperty("ccm.branch");
+@@ -120,7 +124,6 @@ public class CcmBridge implements AutoCloseable {
+   private final Path configDirectory;
+   private final AtomicBoolean started = new AtomicBoolean();
+   private final AtomicBoolean created = new AtomicBoolean();
+-  private final String ipPrefix;
+   private final Map<String, Object> cassandraConfiguration;
+   private final Map<String, Object> dseConfiguration;
+   private final List<String> rawDseYaml;
+@@ -131,7 +134,7 @@ public class CcmBridge implements AutoCloseable {
+   private CcmBridge(
+       Path configDirectory,
+       int[] nodes,
+-      String ipPrefix,
++      String idPrefix,
+       Map<String, Object> cassandraConfiguration,
+       Map<String, Object> dseConfiguration,
+       List<String> dseConfigurationRawYaml,
+@@ -147,7 +150,7 @@ public class CcmBridge implements AutoCloseable {
+     } else {
+       this.nodes = nodes;
+     }
+-    this.ipPrefix = ipPrefix;
++    this.idPrefix = idPrefix;
+     this.cassandraConfiguration = cassandraConfiguration;
+     this.dseConfiguration = dseConfiguration;
+     this.rawDseYaml = dseConfigurationRawYaml;
+@@ -193,24 +196,6 @@ public class CcmBridge implements AutoCloseable {
+     }
+   }
+ 
+-  private String getCcmVersionString(Version version) {
+-    // for 4.0 pre-releases, the CCM version string needs to be "4.0-alpha1" or "4.0-alpha2"
+-    // Version.toString() always adds a patch value, even if it's not specified when parsing.
+-    if (version.getMajor() == 4
+-        && version.getMinor() == 0
+-        && version.getPatch() == 0
+-        && version.getPreReleaseLabels() != null) {
+-      // truncate the patch version from the Version string
+-      StringBuilder sb = new StringBuilder();
+-      sb.append(version.getMajor()).append('.').append(version.getMinor());
+-      for (String preReleaseString : version.getPreReleaseLabels()) {
+-        sb.append('-').append(preReleaseString);
+-      }
+-      return sb.toString();
+-    }
+-    return version.toString();
+-  }
+-
+   public void create() {
+     if (created.compareAndSet(false, true)) {
+       if (INSTALL_DIRECTORY != null) {
+@@ -219,7 +204,7 @@ public class CcmBridge implements AutoCloseable {
+         createOptions.add("-v git:" + BRANCH.trim().replaceAll("\"", ""));
+ 
+       } else {
+-        createOptions.add("-v " + getCcmVersionString(VERSION));
++        createOptions.add("-v " + SCYLLA_VERSION);
+       }
+       if (DSE_ENABLEMENT) {
+         createOptions.add("--dse");
+@@ -227,18 +212,20 @@ public class CcmBridge implements AutoCloseable {
+       execute(
+           "create",
+           CLUSTER_NAME,
+-          "-i",
+-          ipPrefix,
++          "--scylla",
++          "--id",
++          idPrefix,
+           "-n",
+           Arrays.stream(nodes).mapToObj(n -> "" + n).collect(Collectors.joining(":")),
+           createOptions.stream().collect(Collectors.joining(" ")));
+-
+       for (Map.Entry<String, Object> conf : cassandraConfiguration.entrySet()) {
+         execute("updateconf", String.format("%s:%s", conf.getKey(), conf.getValue()));
++        // LOG.warn("skipping ({}:{})", conf.getKey(), conf.getValue());
+       }
+       if (getCassandraVersion().compareTo(Version.V2_2_0) >= 0) {
+-        execute("updateconf", "enable_user_defined_functions:true");
++        execute("updateconf", "enable_user_defined_functions:true", "experimental_features:[udf]");
+       }
++
+       if (DSE_ENABLEMENT) {
+         for (Map.Entry<String, Object> conf : dseConfiguration.entrySet()) {
+           execute("updatedseconf", String.format("%s:%s", conf.getKey(), conf.getValue()));
+@@ -305,9 +292,9 @@ public class CcmBridge implements AutoCloseable {
+ 
+   public void add(int n, String dc) {
+     if (getDseVersion().isPresent()) {
+-      execute("add", "-i", ipPrefix + n, "-d", dc, "node" + n, "--dse");
++      execute("add", "--scylla", "-d", dc, "node" + n, "--dse");
+     } else {
+-      execute("add", "-i", ipPrefix + n, "-d", dc, "node" + n);
++      execute("add", "--scylla", "-d", dc, "node" + n);
+     }
+     start(n);
+   }
+@@ -323,6 +310,7 @@ public class CcmBridge implements AutoCloseable {
+             + " --config-dir="
+             + configDirectory.toFile().getAbsolutePath();
+ 
++    LOG.warn("Executing: " + command);
+     execute(CommandLine.parse(command));
+   }
+ 
+@@ -426,7 +414,7 @@ public class CcmBridge implements AutoCloseable {
+     private final Map<String, Object> dseConfiguration = new LinkedHashMap<>();
+     private final List<String> dseRawYaml = new ArrayList<>();
+     private final List<String> jvmArgs = new ArrayList<>();
+-    private String ipPrefix = "127.0.0.";
++    private String idPrefix = "0";
+     private final List<String> createOptions = new ArrayList<>();
+     private final List<String> dseWorkloads = new ArrayList<>();
+ 
+@@ -436,13 +424,13 @@ public class CcmBridge implements AutoCloseable {
+       try {
+         this.configDirectory = Files.createTempDirectory("ccm");
+         // mark the ccm temp directories for deletion when the JVM exits
+-        this.configDirectory.toFile().deleteOnExit();
++        // this.configDirectory.toFile().deleteOnExit();
+       } catch (IOException e) {
+         // change to unchecked for now.
+         throw new RuntimeException(e);
+       }
+       // disable auto_snapshot by default to reduce disk usage when destroying schema.
+-      withCassandraConfiguration("auto_snapshot", "false");
++      // withCassandraConfiguration("auto_snapshot", "false");
+     }
+ 
+     public Builder withCassandraConfiguration(String key, Object value) {
+@@ -470,8 +458,8 @@ public class CcmBridge implements AutoCloseable {
+       return this;
+     }
+ 
+-    public Builder withIpPrefix(String ipPrefix) {
+-      this.ipPrefix = ipPrefix;
++    public Builder withIdPrefix(String idPrefix) {
++      this.idPrefix = idPrefix;
+       return this;
+     }
+ 
+@@ -523,7 +511,7 @@ public class CcmBridge implements AutoCloseable {
+       return new CcmBridge(
+           configDirectory,
+           nodes,
+-          ipPrefix,
++          idPrefix,
+           cassandraConfiguration,
+           dseConfiguration,
+           dseRawYaml,
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+index 4ea1b3843..45029cc10 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+@@ -15,6 +15,7 @@
+  */
+ package com.datastax.oss.driver.api.testinfra.ccm;
+ 
++import java.util.concurrent.atomic.AtomicInteger;
+ import java.util.concurrent.atomic.AtomicReference;
+ 
+ /**
+@@ -30,6 +31,8 @@ public class CustomCcmRule extends BaseCcmRule {
+ 
+   private static final AtomicReference<CustomCcmRule> CURRENT = new AtomicReference<>();
+ 
++  private static AtomicInteger cluster_id = new AtomicInteger(1);
++
+   CustomCcmRule(CcmBridge ccmBridge) {
+     super(ccmBridge);
+   }
+@@ -62,6 +65,10 @@ public class CustomCcmRule extends BaseCcmRule {
+ 
+     private final CcmBridge.Builder bridgeBuilder = CcmBridge.builder();
+ 
++    public Builder() {
++      this.withIdPrefix(Integer.toString(cluster_id.incrementAndGet()));
++    }
++
+     public Builder withNodes(int... nodes) {
+       bridgeBuilder.withNodes(nodes);
+       return this;
+@@ -112,6 +119,11 @@ public class CustomCcmRule extends BaseCcmRule {
+       return this;
+     }
+ 
++    public Builder withIdPrefix(String idPrefix) {
++      bridgeBuilder.withIdPrefix(idPrefix);
++      return this;
++    }
++
+     public CustomCcmRule build() {
+       return new CustomCcmRule(bridgeBuilder.build());
+     }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+index 96a0ac5fd..69ee3a550 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+@@ -24,12 +24,13 @@ public class DefaultCcmBridgeBuilderCustomizer {
+   public static CcmBridge.Builder configureBuilder(CcmBridge.Builder builder) {
+     if (!CcmBridge.DSE_ENABLEMENT
+         && CcmBridge.VERSION.nextStable().compareTo(Version.V4_0_0) >= 0) {
+-      builder.withCassandraConfiguration("enable_materialized_views", true);
+-      builder.withCassandraConfiguration("enable_sasi_indexes", true);
++      // builder.withCassandraConfiguration("enable_materialized_views", true);
++      // builder.withCassandraConfiguration("enable_sasi_indexes", true);
+     }
+     if (CcmBridge.VERSION.nextStable().compareTo(Version.V3_0_0) >= 0) {
+-      builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
+-      builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
++      // builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
++      // builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
++      builder.withCassandraConfiguration("skip_wait_for_gossip_to_settle", "0");
+       builder.withCassandraConfiguration("num_tokens", "1");
+       builder.withCassandraConfiguration("initial_token", "0");
+     }


### PR DESCRIPTION
Main difference with 4.17.0 is imports in BaseCcmRule.

Fixes #35
