### PR TITLE
introudce back python2 into the docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y update \
        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/xenial-security.gpg] http://security.ubuntu.com/ubuntu \
        xenial-security main" | tee /etc/apt/sources.list.d/xenial-security.list > /dev/null \
     && apt-get -y update \
-    && apt-get install -y  temurin-8-jdk maven git docker-ce-cli libssl1.0.0 libapr1 \
+    && apt-get install -y  temurin-8-jdk maven git docker-ce-cli python2 libssl1.0.0 libapr1 \
     && apt-get install -y  temurin-11-jdk  \    
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/image
+++ b/scripts/image
@@ -1,1 +1,1 @@
-scylladb/scylla-cassandra-unit-tests:python3.11-20230601
+scylladb/scylla-cassandra-unit-tests:python3.11-20240108


### PR DESCRIPTION
without it cqlsh on older branches like 5.2, would fail to work and the sni test are using cqlsh in ccm flow

Fixes: #37