### PR TITLE
run_test.sh: Define JAVA_HOME inside the container

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -132,6 +132,7 @@ docker_cmd="docker run --init --detach=true \
     -v ${SCYLLA_JAVA_DRIVER_MATRIX_DIR}:${SCYLLA_JAVA_DRIVER_MATRIX_DIR} \
     -e HOME \
     -e SCYLLA_EXT_OPTS \
+    -e JAVA_HOME='/usr/lib/jvm/temurin-8-jdk-amd64/'
     -e WORKSPACE \
     ${BUILD_OPTIONS} \
     ${JOB_OPTIONS} \


### PR DESCRIPTION
This change explicitly defines JAVA_HOME environment variable to point
to Temurin SDK, as due to 4.18.0 update of datastax driver, which
updated maven-surefire-plugin to 3.0.0, maven is unable to locate proper
JDK to use - explicitly defining JDK path fixes the issue
