### PR TITLE
scylla-3.x: Ignore ReconnectionTest

### DIFF
--- a/versions/scylla/3.11.2.4/ignore.yaml
+++ b/versions/scylla/3.11.2.4/ignore.yaml
@@ -7,3 +7,7 @@ tests:
 
   # using 2 node cluster, and stopping one, isn't supported by scylla since raft
   - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+  
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest


### PR DESCRIPTION
One of the tests in this class uses an unsupported option and the
ScyllaSkip annotation seems to first skip, then fail the test anyway due
to this.

Closes #41
Closes #34
