### PR TITLE
datastax: Ignore V5 protocol tests on 4.18.0

### DIFF
--- a/versions/datastax/4.18.0/ignore.yaml
+++ b/versions/datastax/4.18.0/ignore.yaml
@@ -141,3 +141,6 @@ tests:
     # Can't use nowInSeconds with protocol V4
     - NowInSecondsIT
 
+    # V5 protocol checks are not supported in scylla
+    - ProtocolVersionInitialNegotiationIT#should_not_downgrade_if_server_supports_latest_version
+    - ProtocolVersionInitialNegotiationIT#should_use_explicitly_provided_v5


### PR DESCRIPTION
As Scylla does not support protocol version 5 for java-driver those
tests should be skipped.
