### PR TITLE
scripts/run_test.sh: create `~/.shiv` as tmpfs

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -145,6 +145,7 @@ docker_cmd="docker run --init --detach=true \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     ${group_args[@]} \
     --tmpfs ${HOME}/.cache \
+    --tmpfs ${HOME}/.shiv \
     -v ${HOME}/.local:${HOME}/.local \
     -v ${HOME}/.ccm:${HOME}/.ccm \
     -v ${HOME}/.m2:${HOME}/.m2 \


### PR DESCRIPTION
since cqlsh move to use shiv, it's using
this folder `~/.shiv` as a place to extract

in this docker envirment, it didn't exist, and
the user didn't had premission to create it.

mounting it as tmpfs fixes the issue.