### PR TITLE
Rebase 3.11.4.0 patch on top of 3.11.2.4 patch

### DIFF
--- a/versions/scylla/3.11.4.0/ignore.yaml
+++ b/versions/scylla/3.11.4.0/ignore.yaml
@@ -1,2 +1,13 @@
 tests:
-  -
+  # test count on tracing which it's content is different in scylla, should be skipped on scylla
+  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+
+  # disable cause now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest
+
+  # using 2 node cluster, and stopping one, isn't supported by scylla since raft
+  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest

--- a/versions/scylla/3.11.4.0/patch
+++ b/versions/scylla/3.11.4.0/patch
@@ -1,3 +1,179 @@
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+index 4c9ba61fc5..3d0f4fa946 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+@@ -206,7 +206,7 @@ public class CCMBridge implements CCMAccess {
+       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
+     } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+       installArgs.add(" --scylla ");
+-      installArgs.add("-v release:" + inputScyllaVersion);
++      installArgs.add("-v " + inputScyllaVersion);
+ 
+       // Detect Scylla Enterprise - it should start with
+       // a 4-digit year.
+@@ -246,7 +246,8 @@ public class CCMBridge implements CCMAccess {
+     }
+     ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
+ 
+-    GLOBAL_SCYLLA_VERSION_NUMBER = VersionNumber.parse(inputScyllaVersion);
++    GLOBAL_SCYLLA_VERSION_NUMBER =
++        VersionNumber.parse("5.2"); // VersionNumber.parse(inputScyllaVersion);
+ 
+     if (isDse()) {
+       GLOBAL_DSE_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+index 74befba297..e5867e5067 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
++@CCMConfig(jvmArgs = {"--smp", "1"})
+ public class ClusterStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(ClusterStressTest.class);
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+index f44e64dca0..aed5e394c6 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+@@ -597,7 +597,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       allRequests.addAll(requests);
+       allRequests.add(MockRequest.send(pool));
+ 
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 2);
+       Connection connection2 = pool.connections[0].get(1);
+ 
+@@ -625,7 +625,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+ 
+       // Borrowing one more time should resurrect the trashed connection
+       allRequests.addAll(MockRequest.sendMany(1, pool));
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 2);
+ 
+       assertThat(pool.connections[0]).containsExactly(connection2, connection1);
+@@ -664,7 +664,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       allRequests.addAll(requests);
+       allRequests.add(MockRequest.send(pool));
+ 
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 2);
+       reset(factory);
+       Connection connection2 = pool.connections[0].get(1);
+@@ -699,7 +699,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       allRequests.addAll(requests);
+       allRequests.add(MockRequest.send(pool));
+       assertThat(connection2.inFlight.get()).isEqualTo(101);
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 2);
+ 
+       // Borrow again to get the new connection
+@@ -742,7 +742,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       allRequests.addAll(requests);
+       allRequests.add(MockRequest.send(pool));
+ 
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertThat(pool.connections[0]).hasSize(2);
+ 
+       // Return enough times to get back under the threshold where one connection is enough
+@@ -988,7 +988,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+ 
+       // Should not have tried to create a new core connection since reconnection time had not
+       // elapsed.
+-      verify(factory, never()).open(any(HostConnectionPool.class));
++      verify(factory, never()).open(any(HostConnectionPool.class), anyInt(), anyInt());
+ 
+       // Sleep to elapse the Reconnection Policy.
+       Uninterruptibles.sleepUninterruptibly(reconnectInterval, TimeUnit.MILLISECONDS);
+@@ -1003,7 +1003,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       // Should have tried to open up to core connections as result of borrowing a connection past
+       // reconnect time and not being at core.
+       blockingExecutor.blockUntilNextTaskCompleted();
+-      verify(factory).open(any(HostConnectionPool.class));
++      verify(factory).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       reset(factory);
+ 
+       // Sleep for reconnect interval to allow reconnection time to elapse.
+@@ -1019,7 +1019,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       blockingExecutor.reset();
+       allRequests.add(MockRequest.send(pool));
+       blockingExecutor.blockUntilNextTaskCompleted();
+-      verify(factory).open(any(HostConnectionPool.class));
++      verify(factory).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       reset(factory);
+ 
+       // Another core connection should be opened as result of another request to get us up to core
+@@ -1027,14 +1027,14 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       blockingExecutor.reset();
+       allRequests.add(MockRequest.send(pool));
+       blockingExecutor.blockUntilNextTaskCompleted();
+-      verify(factory).open(any(HostConnectionPool.class));
++      verify(factory).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       reset(factory);
+ 
+       // Sending another request should not grow the pool any more, since we are now at core
+       // connections.
+       allRequests.add(MockRequest.send(pool));
+       verify(factory, after((reconnectInterval + readTimeout) * 2).never())
+-          .open(any(HostConnectionPool.class));
++          .open(any(HostConnectionPool.class), anyInt(), anyInt());
+     } finally {
+       MockRequest.completeAll(allRequests);
+       cluster.close();
+@@ -1082,7 +1082,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       }
+ 
+       // Pool should grow by 1.
+-      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, after(2000).times(1)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertThat(pool.connections[0]).hasSize(2);
+ 
+       // Reset factory mock as we'll be checking for new open() invokes later.
+@@ -1110,7 +1110,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       assertThat(pool.connections[0]).hasSize(1);
+ 
+       // A new connection should never have been spawned since we didn't max out core.
+-      verify(factory, after(readTimeout).never()).open(any(HostConnectionPool.class));
++      verify(factory, after(readTimeout).never())
++          .open(any(HostConnectionPool.class), anyInt(), anyInt());
+ 
+       // Borrow another connection, since we exceed max another connection should be opened.
+       MockRequest request = MockRequest.send(pool);
+@@ -1118,7 +1119,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       assertThat(request.getConnection()).isEqualTo(extra1);
+ 
+       // After some time the a connection should attempt to be opened (but will fail).
+-      verify(factory, timeout(readTimeout)).open(any(HostConnectionPool.class));
++      verify(factory, timeout(readTimeout)).open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 1);
+       assertThat(pool.connections[0]).hasSize(1);
+ 
+@@ -1314,7 +1315,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       MockRequest request = MockRequest.send(pool, 1);
+ 
+       // Should create up to core connections.
+-      verify(factory, timeout(readTimeout * 8).times(8)).open(any(HostConnectionPool.class));
++      verify(factory, timeout(readTimeout * 8).times(8))
++          .open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 8);
+ 
+       request.simulateSuccessResponse();
+@@ -1365,7 +1367,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
+       MockRequest request = MockRequest.send(pool, 1);
+ 
+       // Should create up to core connections.
+-      verify(factory, timeout(readTimeout).times(1)).open(any(HostConnectionPool.class));
++      verify(factory, timeout(readTimeout).times(1))
++          .open(any(HostConnectionPool.class), anyInt(), anyInt());
+       assertPoolSize(pool, 1);
+       Uninterruptibles.getUninterruptibly(request.requestInitialized, 10, TimeUnit.SECONDS);
+       request.simulateSuccessResponse();
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
 index 09f8bf8edb..4f01cb47a6 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -20,3 +196,81 @@ index 09f8bf8edb..4f01cb47a6 100644
  
        try {
          cluster.init();
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+index fbdf187a70..dd1c345929 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+@@ -45,7 +45,9 @@ import org.mockito.stubbing.Answer;
+ import org.testng.annotations.Test;
+ 
+ @CreateCCM(PER_METHOD)
+-@CCMConfig(createCluster = false)
++@CCMConfig(
++    createCluster = false,
++    jvmArgs = {"--smp", "1"})
+ public class NettyOptionsTest extends CCMTestsSupport {
+ 
+   @Test(groups = "short")
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+index b3d6be0f3c..30fafa5273 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+@@ -24,6 +24,7 @@ package com.datastax.driver.core;
+ import static com.datastax.driver.core.Assertions.assertThat;
+ import static com.datastax.driver.core.CreateCCM.TestMode.PER_METHOD;
+ import static java.util.concurrent.TimeUnit.SECONDS;
++import static org.assertj.core.api.Assertions.assertThat;
+ import static org.mockito.Mockito.reset;
+ import static org.mockito.Mockito.spy;
+ import static org.mockito.Mockito.times;
+@@ -218,7 +219,10 @@ public class ReconnectionTest extends CCMTestsSupport {
+    * The connection established by a successful reconnection attempt should be reused in one of the
+    * connection pools (JAVA-505).
+    */
+-  @CCMConfig(dirtiesContext = true, createCluster = false)
++  @CCMConfig(
++      dirtiesContext = true,
++      createCluster = false,
++      jvmArgs = {"--smp", "1"})
+   @Test(groups = "long")
+   public void should_use_connection_from_reconnection_in_pool() {
+     TogglabePolicy loadBalancingPolicy = new TogglabePolicy(new RoundRobinPolicy());
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+index aa0f573795..6eaa74e318 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+@@ -19,6 +19,7 @@ import static com.datastax.driver.core.Assertions.assertThat;
+ import static com.datastax.driver.core.CreateCCM.TestMode.PER_METHOD;
+ import static com.google.common.collect.Lists.newArrayList;
+ import static java.util.concurrent.TimeUnit.MINUTES;
++import static org.assertj.core.api.Assertions.assertThat;
+ import static org.assertj.core.api.Assertions.fail;
+ 
+ import com.datastax.driver.core.exceptions.InvalidQueryException;
+@@ -27,7 +28,10 @@ import java.util.concurrent.TimeUnit;
+ import org.testng.annotations.Test;
+ 
+ @CreateCCM(PER_METHOD)
+-@CCMConfig(dirtiesContext = true, createCluster = false)
++@CCMConfig(
++    dirtiesContext = true,
++    createCluster = false,
++    jvmArgs = {"--smp", "1"})
+ public class SessionLeakTest extends CCMTestsSupport {
+ 
+   SocketChannelMonitor channelMonitor;
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+index ea75f84544..ea70e9081a 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
+-@CCMConfig(dirtiesContext = true)
++@CCMConfig(
++    dirtiesContext = true,
++    jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"})
+ public class SessionStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);


### PR DESCRIPTION
Order of operations: checkout driver 3.11.4.0, apply 3.11.2.4 patch, apply old 3.11.4.0 patch, generate the new patch file and replace 3.11.4.0 patch file. All patches applied cleanly without conflicts.

Fixes #56.