### PR TITLE
Add bugfix for scylla 3.11.4.0 patch

### DIFF
--- a/versions/scylla/3.11.4.0/patch
+++ b/versions/scylla/3.11.4.0/patch
@@ -540,19 +540,21 @@ index ea75f8454..ea70e9081 100644
  
    private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
-index eb77f2bf2..ab574d8a4 100644
+index eb77f2bf2..9d4f1e50c 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
-@@ -52,7 +52,15 @@ public class StateListenerTest extends CCMTestsSupport {
+@@ -52,7 +52,17 @@ public class StateListenerTest extends CCMTestsSupport {
      ccm().start(1);
      listener.waitForEvent();
  
 -    listener.setExpectedEvent(REMOVE);
 +    // Different expectation for Scylla versions since 6.0.0 and 2024.2, both included
++    VersionNumber minOss = VersionNumber.parse("6.0.0");
++    VersionNumber minEnterprise = VersionNumber.parse("2024.2");
 +    VersionNumber scyllaVer = ccm().getScyllaVersion();
-+    if (scyllaVer != null
-+        && ((scyllaVer.getMajor() >= 6 && scyllaVer.getMajor() <= 9)
-+            || (scyllaVer.getMajor() >= 2024 && scyllaVer.getMinor() >= 2))) {
++    boolean isEnterprise = scyllaVer.getMajor() >= 2017;
++    if ((isEnterprise && scyllaVer.compareTo(minEnterprise) >= 0)
++        || (!isEnterprise && scyllaVer.compareTo(minOss) >= 0)) {
 +      listener.setExpectedEvent(DOWN);
 +    } else {
 +      listener.setExpectedEvent(REMOVE);


### PR DESCRIPTION
Due to a bug StateListenerTest sets up wrong expectation for Scylla versions 2025.1.x. Fixes comparison responsible for that.