### PR TITLE
More adjustments for scylla patch 3.11.5.3

### DIFF
--- a/versions/scylla/3.11.5.3/patch
+++ b/versions/scylla/3.11.5.3/patch
@@ -1,26 +1,260 @@
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
-index 4c9ba61fc..3d0f4fa94 100644
+index 4c9ba61fc..80d461aa5 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
-@@ -206,7 +206,7 @@ public class CCMBridge implements CCMAccess {
+@@ -194,6 +194,7 @@ public class CCMBridge implements CCMAccess {
+   static {
+     String inputCassandraVersion = System.getProperty("cassandra.version");
+     String inputScyllaVersion = System.getProperty("scylla.version");
++    GLOBAL_SCYLLA_VERSION_NUMBER = parseScyllaInputVersion(inputScyllaVersion);
+ 
+     String installDirectory = System.getProperty("cassandra.directory");
+     String branch = System.getProperty("cassandra.branch");
+@@ -206,8 +207,11 @@ public class CCMBridge implements CCMAccess {
        installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
      } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
        installArgs.add(" --scylla ");
 -      installArgs.add("-v release:" + inputScyllaVersion);
-+      installArgs.add("-v " + inputScyllaVersion);
- 
+-
++      if (isVersionNumber(inputScyllaVersion)) {
++        installArgs.add("-v release:" + inputScyllaVersion);
++      } else {
++        installArgs.add("-v " + inputScyllaVersion);
++      }
        // Detect Scylla Enterprise - it should start with
        // a 4-digit year.
-@@ -246,7 +246,8 @@ public class CCMBridge implements CCMAccess {
+       if (inputScyllaVersion.matches("\\d{4}\\..*")) {
+@@ -246,8 +250,6 @@ public class CCMBridge implements CCMAccess {
      }
      ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
  
 -    GLOBAL_SCYLLA_VERSION_NUMBER = VersionNumber.parse(inputScyllaVersion);
-+    GLOBAL_SCYLLA_VERSION_NUMBER =
-+        VersionNumber.parse("5.2"); // VersionNumber.parse(inputScyllaVersion);
- 
+-
      if (isDse()) {
        GLOBAL_DSE_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+       GLOBAL_CASSANDRA_VERSION_NUMBER = CCMBridge.getCassandraVersion(GLOBAL_DSE_VERSION_NUMBER);
+@@ -256,6 +258,14 @@ public class CCMBridge implements CCMAccess {
+           GLOBAL_DSE_VERSION_NUMBER,
+           GLOBAL_CASSANDRA_VERSION_NUMBER,
+           CASSANDRA_INSTALL_ARGS);
++    } else if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
++      GLOBAL_CASSANDRA_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
++      GLOBAL_DSE_VERSION_NUMBER = null;
++      logger.info(
++          "Tests requiring CCM will by default use Scylla version {} and report Cassandra version {} when asked specifically for it (install arguments: {})",
++          GLOBAL_SCYLLA_VERSION_NUMBER,
++          GLOBAL_CASSANDRA_VERSION_NUMBER,
++          CASSANDRA_INSTALL_ARGS);
+     } else {
+       GLOBAL_CASSANDRA_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+       GLOBAL_DSE_VERSION_NUMBER = null;
+@@ -338,12 +348,40 @@ public class CCMBridge implements CCMAccess {
+     return osName != null && osName.startsWith("Windows");
+   }
+ 
++  private static boolean isVersionNumber(String versionString) {
++    try {
++      VersionNumber.parse(versionString);
++    } catch (IllegalArgumentException e) {
++      return false;
++    }
++    return true;
++  }
++
++  private static VersionNumber parseScyllaInputVersion(String versionString) {
++    VersionNumber parsedScyllaVersionNumber = null;
++    try {
++      parsedScyllaVersionNumber = VersionNumber.parse(versionString);
++    } catch (IllegalArgumentException e) {
++      logger.warn(
++          "Failed to parse scylla.version: " + versionString + ". Trying to get it through CCM.",
++          e);
++      parsedScyllaVersionNumber = getScyllaVersionThroughCcm(versionString);
++      logger.info(
++          String.format(
++              "Version string %s corresponds here to version number %s",
++              versionString, parsedScyllaVersionNumber));
++    }
++    return parsedScyllaVersionNumber;
++  }
++
+   private final String clusterName;
+ 
+   private final VersionNumber cassandraVersion;
+ 
+   private final VersionNumber dseVersion;
+ 
++  private final VersionNumber scyllaVersion;
++
+   private final int storagePort;
+ 
+   private final int thriftPort;
+@@ -378,6 +416,7 @@ public class CCMBridge implements CCMAccess {
+       String clusterName,
+       VersionNumber cassandraVersion,
+       VersionNumber dseVersion,
++      VersionNumber scyllaVersion,
+       String ipPrefix,
+       int storagePort,
+       int thriftPort,
+@@ -391,6 +430,7 @@ public class CCMBridge implements CCMAccess {
+     this.clusterName = clusterName;
+     this.cassandraVersion = cassandraVersion;
+     this.dseVersion = dseVersion;
++    this.scyllaVersion = scyllaVersion;
+     this.ipPrefix = ipPrefix;
+     this.storagePort = storagePort;
+     this.thriftPort = thriftPort;
+@@ -465,6 +505,11 @@ public class CCMBridge implements CCMAccess {
+     return dseVersion;
+   }
+ 
++  @Override
++  public VersionNumber getScyllaVersion() {
++    return scyllaVersion;
++  }
++
+   @Override
+   public File getCcmDir() {
+     return ccmDir;
+@@ -792,7 +837,25 @@ public class CCMBridge implements CCMAccess {
+     execute(CCM_COMMAND + " node%d setworkload %s", node, workloadStr);
+   }
+ 
+-  private String execute(String command, Object... args) {
++  private static VersionNumber getScyllaVersionThroughCcm(String versionString) {
++    File configDir = Files.createTempDir();
++    try {
++      execute(configDir, "ccm create get_version -n 1 --scylla --version %s", versionString);
++      String versionOutput = execute(configDir, "ccm node1 versionfrombuild");
++      return VersionNumber.parse(versionOutput.replace("ccmout> ", "").trim());
++    } catch (RuntimeException cause) {
++      throw new RuntimeException(
++          "Error during getting Scylla version through ccm commands.", cause);
++    } finally {
++      try {
++        execute(configDir, "ccm remove get_version");
++      } catch (Exception ignored) {
++      }
++    }
++  }
++
++  private static String execute(File ccmDir, String command, Object... args) {
++    Logger logger = CCMBridge.logger;
+     String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;
+     Closer closer = Closer.create();
+     // 10 minutes timeout
+@@ -856,6 +919,10 @@ public class CCMBridge implements CCMAccess {
+     return sw.toString();
+   }
+ 
++  private String execute(String command, Object... args) {
++    return execute(this.ccmDir, command, args);
++  }
++
+   /**
+    * Waits for a host to be up by pinging the TCP socket directly, without using the Java driver's
+    * API.
+@@ -949,10 +1016,12 @@ public class CCMBridge implements CCMAccess {
+     private static final Pattern RANDOM_PORT_PATTERN = Pattern.compile(RANDOM_PORT);
+ 
+     private String ipPrefix = TestUtils.IP_PREFIX;
++    private String providedClusterName = null;
+     int[] nodes = {1};
+     private int[] jmxPorts = {};
+     private boolean start = true;
+     private boolean dse = isDse();
++    private boolean scylla = GLOBAL_SCYLLA_VERSION_NUMBER != null;
+     private boolean startSniProxy = false;
+     private VersionNumber version = null;
+     private final Set<String> createOptions = new LinkedHashSet<String>();
+@@ -991,6 +1060,15 @@ public class CCMBridge implements CCMAccess {
+       return this;
+     }
+ 
++    /**
++     * Builder takes care of naming and numbering clusters on its own. Use if you really need a
++     * specific name
++     */
++    public Builder withClusterName(String clusterName) {
++      this.providedClusterName = clusterName;
++      return this;
++    }
++
+     /** Enables SSL encryption. */
+     public Builder withSSL() {
+       cassandraConfiguration.put("client_encryption_options.enabled", "true");
+@@ -1035,8 +1113,8 @@ public class CCMBridge implements CCMAccess {
+     }
+ 
+     /**
+-     * The Cassandra or DSE version to use. If not specified the globally configured version is used
+-     * instead.
++     * The Cassandra or DSE or Scylla version to use. If not specified the globally configured
++     * version is used instead.
+      */
+     public Builder withVersion(VersionNumber version) {
+       this.version = version;
+@@ -1049,6 +1127,12 @@ public class CCMBridge implements CCMAccess {
+       return this;
+     }
+ 
++    /** Indicates whether or not this cluster is meant to be a Scylla cluster. */
++    public Builder withScylla(boolean scylla) {
++      this.scylla = scylla;
++      return this;
++    }
++
+     /**
+      * Free-form options that will be added at the end of the {@code ccm create} command (defaults
+      * to {@link #CASSANDRA_INSTALL_ARGS} if this is never called).
+@@ -1115,19 +1199,30 @@ public class CCMBridge implements CCMAccess {
+       // be careful NOT to alter internal state (hashCode/equals) during build!
+       String clusterName = TestUtils.generateIdentifier("ccm_");
+ 
++      if (providedClusterName != null) clusterName = providedClusterName;
++
+       VersionNumber dseVersion;
+       VersionNumber cassandraVersion;
++      VersionNumber scyllaVersion;
+       boolean versionConfigured = this.version != null;
+       // No version was explicitly provided, fallback on global config.
+       if (!versionConfigured) {
++        scyllaVersion = GLOBAL_SCYLLA_VERSION_NUMBER;
+         dseVersion = GLOBAL_DSE_VERSION_NUMBER;
+         cassandraVersion = GLOBAL_CASSANDRA_VERSION_NUMBER;
+       } else if (dse) {
+         // given version is the DSE version, base cassandra version on DSE version.
++        scyllaVersion = null;
+         dseVersion = this.version;
+         cassandraVersion = getCassandraVersion(dseVersion);
++      } else if (scylla) {
++        scyllaVersion = this.version;
++        dseVersion = null;
++        // Versions from 5.1 to 6.2.0 seem to report release_version 3.0.8 in system_local
++        cassandraVersion = VersionNumber.parse("3.0.8");
+       } else {
+         // given version is cassandra version.
++        scyllaVersion = null;
+         dseVersion = null;
+         cassandraVersion = this.version;
+       }
+@@ -1182,6 +1277,7 @@ public class CCMBridge implements CCMAccess {
+               clusterName,
+               cassandraVersion,
+               dseVersion,
++              scyllaVersion,
+               ipPrefix,
+               storagePort,
+               thriftPort,
+@@ -1391,6 +1487,7 @@ public class CCMBridge implements CCMAccess {
+ 
+       if (ipPrefix != builder.ipPrefix) return false;
+       if (dse != builder.dse) return false;
++      if (scylla != builder.scylla) return false;
+       if (!Arrays.equals(nodes, builder.nodes)) return false;
+       if (version != null ? !version.equals(builder.version) : builder.version != null)
+         return false;
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
 index 74befba29..e5867e506 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -252,3 +486,38 @@ index ea75f8454..ea70e9081 100644
  public class SessionStressTest extends CCMTestsSupport {
  
    private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
+diff --git a/pom.xml b/pom.xml
+index a6e18dddd..bc8827c6b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -86,6 +86,7 @@
+         <scassandra.version>1.1.2</scassandra.version>
+         <logback.version>1.2.13</logback.version>
+         <byteman.version>3.0.8</byteman.version>
++        <surefire.version>3.0.0-M6</surefire.version>
+         <ipprefix>127.0.1.</ipprefix>
+         <!-- defaults below are overridden by profiles and/or submodules -->
+         <test.groups>unit</test.groups>
+@@ -721,7 +722,7 @@
+ 
+                 <plugin>
+                     <artifactId>maven-surefire-plugin</artifactId>
+-                    <version>3.0.0-M6</version>
++                    <version>${surefire.version}</version>
+                     <configuration>
+                         <groups>${test.groups}</groups>
+                         <useFile>false</useFile>
+@@ -748,6 +749,13 @@
+                             </property>
+                         </properties>
+                     </configuration>
++                    <dependencies>
++                        <dependency>
++                            <groupId>org.apache.maven.surefire</groupId>
++                            <artifactId>surefire-testng</artifactId>
++                            <version>${surefire.version}</version>
++                        </dependency>
++                    </dependencies>
+                 </plugin>
+ 
+                 <plugin>


### PR DESCRIPTION
Checks out a newer version of CCMBridge.
Removes hardcoded in patch Scylla version.
Adds TestNG provider for surefire plugin.