### PR TITLE
Ignore chosen TableMetadataTest methods

### DIFF
--- a/versions/scylla/3.10.2.1/ignore.yaml
+++ b/versions/scylla/3.10.2.1/ignore.yaml
@@ -117,3 +117,12 @@ tests:
 
   # disable cause now CCM uses different ip address and port for the JMX
   - CCMBridgeTest
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table

--- a/versions/scylla/3.11.0.1/ignore.yaml
+++ b/versions/scylla/3.11.0.1/ignore.yaml
@@ -7,3 +7,12 @@ tests:
 
   # using 2 node cluster, and stopping one, isn't supported by scylla since raft
   - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table

--- a/versions/scylla/3.11.2.4/ignore.yaml
+++ b/versions/scylla/3.11.2.4/ignore.yaml
@@ -7,7 +7,16 @@ tests:
 
   # using 2 node cluster, and stopping one, isn't supported by scylla since raft
   - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
-  
+
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
   - ReconnectionTest
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table

--- a/versions/scylla/3.11.4.0/ignore.yaml
+++ b/versions/scylla/3.11.4.0/ignore.yaml
@@ -11,3 +11,12 @@ tests:
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
   - ReconnectionTest
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table

--- a/versions/scylla/3.11.5.3/ignore.yaml
+++ b/versions/scylla/3.11.5.3/ignore.yaml
@@ -11,3 +11,12 @@ tests:
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
   - ReconnectionTest
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table

--- a/versions/scylla/3.7.1.0/ignore.yaml
+++ b/versions/scylla/3.7.1.0/ignore.yaml
@@ -117,3 +117,12 @@ tests:
 
   # disable cause now CCM uses different ip address and port for the JMX
   - CCMBridgeTest
+
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_dynamic_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_static_table
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_compact_table_with_multiple_clustering_columns
+  # 'CREATE TABLE WITH COMPACT STORAGE' is now deprecated
+  - TableMetadataTest#should_parse_dense_table


### PR DESCRIPTION
Adds to ignores the following methods of TableMetadataTest class: should_parse_compact_dynamic_table,
should_parse_compact_static_table,
should_parse_compact_table_with_multiple_clustering_columns, should_parse_dense_table.

All those methods fail with InvalidQueryException: InvalidQuery Support for the deprecated feature of 'CREATE TABLE WITH COMPACT STORAGE' is disabled and will eventually be removed in a future version.  To enable, set the 'enable_create_table_with_compact_storage' config option to 'true'.