### PR TITLE
scylla/4.18.0.2: Add Blockhound exception for ConcurrentMap

### DIFF
--- a/versions/scylla/4.18.0.2/patch
+++ b/versions/scylla/4.18.0.2/patch
@@ -1,3 +1,19 @@
+diff --git a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
+index 7d90c5002..68e59e89c 100644
+--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
++++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
+@@ -107,5 +107,11 @@ public final class DriverBlockHoundIntegration implements BlockHoundIntegration
+     builder.allowBlockingCallsInside("io.netty.util.concurrent.GlobalEventExecutor", "addTask");
+     builder.allowBlockingCallsInside(
+         "io.netty.util.concurrent.SingleThreadEventExecutor", "addTask");
++
++    // Exceptions for scylla-java-driver-matrix
++
++    // Various parallelizable tests sometimes fail due to ConcurrentMap's put.
++    builder.allowBlockingCallsInside(
++        "com.datastax.oss.driver.shaded.guava.common.collect.MapMakerInternalMap", "put");
+   }
+ }
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
 index d70c6d3fa..c9839c3b9 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java


### PR DESCRIPTION
Allows blocking calls inside
`com.datastax.oss.driver.shaded.guava.common.collect.MapMakerInternalMap#put`