### PR TITLE
Make it work properly when there are no tests to ignore

### DIFF
--- a/run.py
+++ b/run.py
@@ -81,7 +81,8 @@ class Run:
             return result
         with (self.version_folder / "ignore.yaml").open(mode="r", encoding="utf-8") as file:
             content = yaml.safe_load(file)
-            result.update(content['tests'])
+            if content and 'tests' in content:
+                result.update(content['tests'])
         return result
 
     @cached_property


### PR DESCRIPTION
Fix following error:
```
20:02:35  ERROR:root:4.19.0.0 failed
20:02:35  Traceback (most recent call last):
20:02:35    File "/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/main.py", line 31, in main
20:02:35      report = runner.run()
20:02:35               ^^^^^^^^^^^^
20:02:35    File "/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/run.py", line 142, in run
20:02:35      if exclude_str := ','.join(f"!{ignore_element}" for ignore_element in self.ignore_tests):
20:02:35                                                                            ^^^^^^^^^^^^^^^^^
20:02:35    File "/usr/local/lib/python3.11/functools.py", line 1001, in __get__
20:02:35      val = self.func(instance)
20:02:35            ^^^^^^^^^^^^^^^^^^^
20:02:35    File "/jenkins/workspace/scylla-master/driver-tests/java-driver-matrix-test/scylla-java-driver-matrix/run.py", line 84, in ignore_tests
20:02:35      result.update(content['tests'])
20:02:35  TypeError: 'NoneType' object is not iterable
```