### PR TITLE
Check if list of tests to ignore is parsed as `None`

### DIFF
--- a/run.py
+++ b/run.py
@@ -81,7 +81,7 @@ class Run:
             return result
         with ignore_file_path.open(mode="r", encoding="utf-8") as file:
             content = yaml.safe_load(file)
-            if content and isinstance(content, dict) and 'tests' in content:
+            if content and isinstance(content, dict) and 'tests' in content and content['tests'] is not None:
                 result.update(content['tests'])
         return result
 


### PR DESCRIPTION
When provided with empty list of tests to ignore (e.g. just "tests:" string), `yaml.safe_load(file)` will produce a dict containing key `'tests'` with value `None`. This results in TypeError since `None` is not iterable. This change adds one extra check for `None` value.