### PR TITLE
Update 4.x scylla driver test cli

### DIFF
--- a/run.py
+++ b/run.py
@@ -158,7 +158,14 @@ class Run:
 
         shutil.rmtree(self._report_path, ignore_errors=True)
         if self._scylla_version:
-            cmd += f" -Dscylla.version={self._scylla_version} -Dccm.scylla"
+            if self._tag.startswith('3') or self._driver_type != 'scylla':
+                cmd += f" -Dscylla.version={self._scylla_version}"
+            else:
+                # Way it works after 4.19.0.0 `ccm.distribution` was introduced
+                cmd += f" -Dccm.version={self._scylla_version} -Dccm.distribution=scylla"
+                # Before 4.19.0.0 it required a flag:
+                cmd += f" -Dccm.scylla"
+
         elif self._scylla_install_dir:
             cmd += f" -Dccm.directory={self._scylla_install_dir}"
         else:


### PR DESCRIPTION
After `4.19.0.0` cli requires `-Dccm.distribution=scylla` or `-Dccm.scylla` to be present alongside with `-Dccm.version`.
Before it required `-Dccm.scylla` and `-Dccm.version` and even before that just `-Dscylla.version`.

We also plan to remove `-Dccm.scylla` in favor of `-Dccm.distributon=scylla`.

This PR combines all of that to make sure cli matches all the requirements for all possible version. 