### PR TITLE
Switch to running integration-test phase for 4.x versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,11 +89,11 @@ if __name__ == '__main__':
                         nargs='?', default='')
     parser.add_argument('--versions', default=[],
                         help='java-driver versions to test')
-    parser.add_argument('--tests', default='*',
-                        help='tests to pass to nosetests tool, default=tests.integration.standard')
+    parser.add_argument('--tests', default='',
+                        help='Initial tests list to pass along. Runner will modify it according to ignore.yaml from version patch. default=\'\'')
     parser.add_argument('--scylla-version', help="relocatable scylla version to use", default=os.environ.get('SCYLLA_VERSION', None))
     parser.add_argument('--recipients', help="whom to send mail at the end of the run",  nargs='+', default=None)
-    parser.add_argument('--driver-type', help='Type of python-driver ("scylla", "cassandra" or "datastax")',
+    parser.add_argument('--driver-type', help='Type of java-driver ("scylla", "cassandra" or "datastax")',
                         dest='driver_type', default='datastax')
     parser.add_argument('--version-size', help='The number of the latest versions that will test.'
                                                'The version is filtered by the major and minor values.'

--- a/processjunit.py
+++ b/processjunit.py
@@ -21,7 +21,7 @@ class ProcessJUnit:
 
         new_tree = ElementTree.Element("testsuite")
         is_first_run = True
-        for file_path in self.tests_result_path.glob("*.xml"):
+        for file_path in self.tests_result_path.glob("TEST-*.xml"):
             tree = ElementTree.parse(file_path)
             testsuite_element = next(tree.iter("testsuite"))
             for key in self._summary:


### PR DESCRIPTION
Previously the matrix would run integration testing through surefire plugin during the `test` phase instead of `integration-test`. Surefire plugin is generally considered to be made for unit testing and not integration testing.
Such setup makes it skip configuration included in pom.xml for integration testing that is tied to the failsafe plugin.

In order to return to proper setup this change switches to running `integration-test` phase which is handled by maven-failsafe-plugin. 

This includes a few adjustments which are:
The reports directory is now `failsafe-reports` and not `surefire-reports` (4.x), 
the test report pattern now includes the `TEST-` prefix which skips unexpected summary files for the groups of tests,
`-Dtest='<ignore list>'` was replaced with appropriate for failsafe plugin `-Dit.test='<ignores list>'` with default initial list being empty string rather than `'*'`.