### PR TITLE
Backport fixes for TabletMapListenerTest to 3.11.5.7 patch

### DIFF
--- a/versions/scylla/3.11.5.7/patch
+++ b/versions/scylla/3.11.5.7/patch
@@ -1,5 +1,22 @@
+diff --git a/driver-core/pom.xml b/driver-core/pom.xml
+index b534f8869b..d0a11c8af8 100644
+--- a/driver-core/pom.xml
++++ b/driver-core/pom.xml
+@@ -202,6 +202,12 @@
+             <scope>test</scope>
+         </dependency>
+ 
++        <dependency>
++            <groupId>org.awaitility</groupId>
++            <artifactId>awaitility</artifactId>
++            <scope>test</scope>
++        </dependency>
++
+ 
+     </dependencies>
+ 
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
-index 80d461aa5..de1867dea 100644
+index 80d461aa5e..de1867dea6 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
 @@ -1348,6 +1348,9 @@ public class CCMBridge implements CCMAccess {
@@ -13,7 +30,7 @@ index 80d461aa5..de1867dea 100644
          allJvmArgs.append(quote);
          allJvmArgs.append("--jvm_arg=");
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
-index 2f340b3a7..636763691 100644
+index 2f340b3a77..6367636914 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
 @@ -32,6 +32,7 @@ public class CCMBridgeTest extends CCMTestsSupport {
@@ -25,7 +42,7 @@ index 2f340b3a7..636763691 100644
    public void should_make_JMX_connection() throws Exception {
      InetSocketAddress addr1 = ccm().jmxAddressOfNode(1);
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
-index 74befba29..e5867e506 100644
+index 74befba297..e5867e5067 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
 @@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
@@ -37,7 +54,7 @@ index 74befba29..e5867e506 100644
  
    private static final Logger logger = LoggerFactory.getLogger(ClusterStressTest.class);
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
-index 7fa9c8550..9ac6b9135 100644
+index 7fa9c8550a..9ac6b9135e 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
 @@ -119,13 +119,14 @@ public class ControlConnectionTest extends CCMTestsSupport {
@@ -59,7 +76,7 @@ index 7fa9c8550..9ac6b9135 100644
      assertThat(fooType.getFieldNames()).containsExactly("i");
    }
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
-index 34d382dcb..097d502da 100644
+index 34d382dcb8..097d502da2 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
 @@ -597,7 +597,7 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
@@ -108,7 +125,7 @@ index 34d382dcb..097d502da 100644
  
        // Return enough times to get back under the threshold where one connection is enough
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
-index 168b86730..27bf7ac5a 100644
+index 168b86730f..27bf7ac5aa 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
 @@ -775,6 +775,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
@@ -120,7 +137,7 @@ index 168b86730..27bf7ac5a 100644
      PreparedStatement prepared =
          session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
-index 0538cf87e..d57301bb7 100644
+index 0538cf87e0..d57301bb7e 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
 @@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
@@ -133,7 +150,7 @@ index 0538cf87e..d57301bb7 100644
  
    private static final int NOTIF_TIMEOUT_MS = 5000;
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
-index aa0f57379..b7c0145a1 100644
+index aa0f573795..b7c0145a18 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
 @@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.fail;
@@ -208,7 +225,7 @@ index aa0f57379..b7c0145a1 100644
    }
  }
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
-index ea75f8454..ea70e9081 100644
+index ea75f84544..ea70e9081a 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
 @@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
@@ -223,7 +240,7 @@ index ea75f8454..ea70e9081 100644
  
    private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
-index 777ea439f..4c7113eb8 100644
+index 777ea439f8..4c7113eb81 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
 @@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.entry;
@@ -282,3 +299,185 @@ index 777ea439f..4c7113eb8 100644
    public void should_parse_compact_table_with_multiple_clustering_columns() {
      TestUtils.compactStorageSupportCheck(ccm());
      // given
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TabletMapListenerTest.java b/driver-core/src/test/java/com/datastax/driver/core/TabletMapListenerTest.java
+index 2953c9d6f5..4da7ecb2dd 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TabletMapListenerTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TabletMapListenerTest.java
+@@ -2,6 +2,7 @@ package com.datastax.driver.core;
+ 
+ import static com.datastax.driver.core.Assertions.assertThat;
+ import static com.datastax.driver.core.Metadata.handleId;
++import static org.awaitility.Awaitility.await;
+ import static org.mockito.Matchers.anyObject;
+ import static org.mockito.Mockito.after;
+ import static org.mockito.Mockito.mock;
+@@ -43,7 +44,7 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+   private static final String CREATE_KEYSPACE = CREATE_TABLETS_KEYSPACE_QUERY;
+   private static final String ALTER_KEYSPACE =
+       "ALTER KEYSPACE " + KEYSPACE_NAME + " WITH durable_writes = false";
+-  private static final String DROP_KEYSPACE = "DROP KEYSPACE " + KEYSPACE_NAME;
++  private static final String DROP_KEYSPACE = "DROP KEYSPACE IF EXISTS " + KEYSPACE_NAME;
+ 
+   private static final String CREATE_TABLE =
+       "CREATE TABLE " + KEYSPACE_NAME + "." + TABLE_NAME + "(i int primary key)";
+@@ -56,6 +57,8 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+   private static final String ALTER_TABLE =
+       "ALTER TABLE " + KEYSPACE_NAME + "." + TABLE_NAME + " ADD j int";
+   private static final String DROP_TABLE = "DROP TABLE " + KEYSPACE_NAME + "." + TABLE_NAME;
++  private static final TabletMap.KeyspaceTableNamePair TABLET_MAP_KEY =
++      new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME));
+ 
+   /** The maximum time that the test will wait to check that listeners have been notified. */
+   private static final long NOTIF_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(1);
+@@ -94,16 +97,15 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+     tabletMap = cluster.getMetadata().getTabletMap();
+ 
+     session.execute(CREATE_TABLE);
+-    assertThat(tabletMap.getMapping())
+-        .doesNotContainKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> !tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(String.format(INSERT_QUERY_TEMPLATE, "42"));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    assertThat(tabletMap.getMapping())
+-        .containsKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    executeOnAllHosts(session.prepare(SELECT_PK_WHERE).bind(42), session);
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(ALTER_TABLE);
+     for (SchemaChangeListener listener : listeners) {
+@@ -114,16 +116,15 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+       assertThat(previous.getValue().getKeyspace()).hasName(handleId(KEYSPACE_NAME));
+       assertThat(previous.getValue()).hasName(handleId(TABLE_NAME));
+     }
+-    assertThat(tabletMap.getMapping())
+-        .doesNotContainKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> !tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(String.format(INSERT_ALTERED_TEMPLATE, "42", "42"));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    assertThat(tabletMap.getMapping())
+-        .containsKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    executeOnAllHosts(session.prepare(SELECT_PK_WHERE).bind(42), session);
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(DROP_TABLE);
+     ArgumentCaptor<TableMetadata> removed = null;
+@@ -133,12 +134,10 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+       assertThat(removed.getValue().getKeyspace()).hasName(handleId(KEYSPACE_NAME));
+       assertThat(removed.getValue()).hasName(handleId(TABLE_NAME));
+     }
+-    assert removed != null;
+-    assertThat(tabletMap.getMapping())
+-        .doesNotContainKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
+-
+-    session.execute(DROP_KEYSPACE);
++    assertThat(removed).isNotNull();
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> !tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+   }
+ 
+   @Test(groups = "short")
+@@ -157,13 +156,10 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+ 
+     session.execute(CREATE_TABLE);
+     session.execute(String.format(INSERT_QUERY_TEMPLATE, "42"));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    assertThat(tabletMap.getMapping())
+-        .containsKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
+-
+-    assertThat(cluster.getMetadata().getKeyspace(KEYSPACE_NAME).isDurableWrites()).isTrue();
++    executeOnAllHosts(session.prepare(SELECT_PK_WHERE).bind(42), session);
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(ALTER_KEYSPACE);
+     assertThat(cluster.getMetadata().getKeyspace(KEYSPACE_NAME)).isNotDurableWrites();
+@@ -178,16 +174,14 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+       verify(listener, after((int) SHORT_TIMEOUT_MS).never())
+           .onTableChanged(anyObject(), anyObject());
+     }
+-    assertThat(tabletMap.getMapping())
+-        .doesNotContainKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
+-
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
+-    session.execute(session.prepare(SELECT_PK_WHERE).bind(42));
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> !tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+-    assertThat(tabletMap.getMapping())
+-        .containsKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    executeOnAllHosts(session.prepare(SELECT_PK_WHERE).bind(42), session);
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+ 
+     session.execute(DROP_KEYSPACE);
+     for (SchemaChangeListener listener : listeners) {
+@@ -195,14 +189,23 @@ public class TabletMapListenerTest extends CCMTestsSupport {
+       verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onKeyspaceRemoved(removed.capture());
+       assertThat(removed.getValue()).hasName(handleId(KEYSPACE_NAME));
+     }
+-    assertThat(tabletMap.getMapping())
+-        .doesNotContainKey(
+-            new TabletMap.KeyspaceTableNamePair(handleId(KEYSPACE_NAME), handleId(TABLE_NAME)));
++    await()
++        .atMost(SHORT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
++        .until(() -> !tabletMap.getMapping().containsKey(TABLET_MAP_KEY));
+   }
+ 
+   @AfterMethod(groups = "short", alwaysRun = true)
+   public void teardown() {
+-    if (session != null) session.close();
++    if (session != null) {
++      session.execute(DROP_KEYSPACE);
++      session.close();
++    }
+     if (cluster != null) cluster.close();
+   }
++
++  private void executeOnAllHosts(Statement statement, Session session) {
++    for (Host host : session.getCluster().getMetadata().getAllHosts()) {
++      session.execute(statement.setHost(host));
++    }
++  }
+ }
+diff --git a/pom.xml b/pom.xml
+index 6bea6944d3..55bd86f1ec 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -411,6 +411,12 @@
+                 <version>${burningwave.tools.version}</version>
+             </dependency>
+ 
++            <dependency>
++                <groupId>org.awaitility</groupId>
++                <artifactId>awaitility</artifactId>
++                <version>4.3.0</version>
++            </dependency>
++
+         </dependencies>
+ 
+     </dependencyManagement>


### PR DESCRIPTION
Backports the fixes which include adding Awaitility dependency and using it in the test to wait for tablet changes to propagate.