### PR TITLE
Backport fix to metrics ITs

### DIFF
--- a/versions/datastax/4.18.1/patch
+++ b/versions/datastax/4.18.1/patch
@@ -1,5 +1,5 @@
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
-index c7b51c040..ed202b1d4 100644
+index c7b51c040b..ed202b1d41 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
 @@ -61,7 +61,7 @@ public class NodeMetadataIT {
@@ -11,8 +11,80 @@ index c7b51c040..ed202b1d4 100644
        if (!CcmBridge.DSE_ENABLEMENT) {
          // CcmBridge does not report accurate C* versions for DSE, only approximated values
          assertThat(node.getCassandraVersion()).isEqualTo(ccmRule.getCassandraVersion());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+index e0184516e2..c0c086179c 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.core.metrics.Metrics;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+ import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+ import java.util.ArrayList;
+ import java.util.List;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class DropwizardMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+index c38df1e202..29479f27ee 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -40,9 +39,9 @@ import io.micrometer.core.instrument.Tag;
+ import io.micrometer.core.instrument.Timer;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicrometerMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+index aa04c058a4..5d0a67f8aa 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
+ import org.eclipse.microprofile.metrics.Tag;
+ import org.eclipse.microprofile.metrics.Timer;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicroProfileMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/test-infra/revapi.json b/test-infra/revapi.json
-index 3cfbc8b53..0fa33a041 100644
+index 3cfbc8b533..0fa33a0415 100644
 --- a/test-infra/revapi.json
 +++ b/test-infra/revapi.json
 @@ -171,6 +171,16 @@
@@ -33,7 +105,7 @@ index 3cfbc8b53..0fa33a041 100644
      ]
    }
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
-index b8b684ee5..0957e6e9b 100644
+index b8b684ee5b..0957e6e9b5 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 @@ -20,9 +20,14 @@ package com.datastax.oss.driver.api.testinfra.ccm;
@@ -66,7 +138,7 @@ index b8b684ee5..0957e6e9b 100644
    public Statement apply(Statement base, Description description) {
      if (BackendRequirementRule.meetsDescriptionRequirements(description)) {
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
-index 98739e771..36543ae76 100644
+index 98739e7715..36543ae762 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 @@ -57,6 +57,10 @@ public class CcmBridge implements AutoCloseable {
@@ -233,7 +305,7 @@ index 98739e771..36543ae76 100644
            dseConfiguration,
            dseRawYaml,
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
-index 58bafd438..4dcec76b5 100644
+index 58bafd438f..4dcec76b5d 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 @@ -17,6 +17,7 @@
@@ -277,7 +349,7 @@ index 58bafd438..4dcec76b5 100644
        return new CustomCcmRule(bridgeBuilder.build());
      }
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
-index ac2507cec..3708d3ca6 100644
+index ac2507cec5..3708d3ca6a 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
 @@ -26,12 +26,13 @@ public class DefaultCcmBridgeBuilderCustomizer {

--- a/versions/datastax/4.19.0/patch
+++ b/versions/datastax/4.19.0/patch
@@ -1,5 +1,5 @@
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
-index 326c05eb1..02aac05d6 100644
+index 326c05eb15..02aac05d63 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
 @@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
@@ -43,7 +43,7 @@ index 326c05eb1..02aac05d6 100644
        type = BackendType.CASSANDRA,
        minInclusive = "4.0",
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
-index c0cf0b78e..08cccf355 100644
+index c0cf0b78e7..08cccf3555 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
 @@ -44,6 +44,7 @@ import java.util.HashSet;
@@ -73,7 +73,7 @@ index c0cf0b78e..08cccf355 100644
    public void should_never_warn_when_session_init_fails() {
      SIMULACRON_RULE
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
-index 3dad08f4d..10402b1ce 100644
+index 3dad08f4de..10402b1cee 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
 @@ -37,6 +37,7 @@ import java.time.Duration;
@@ -103,7 +103,7 @@ index 3dad08f4d..10402b1ce 100644
    public void should_execute_queries_with_lz4_compression() throws Exception {
      createAndCheckCluster("lz4");
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
-index a14c3b29b..8edf2910a 100644
+index a14c3b29b2..8edf2910a1 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
 @@ -37,6 +37,7 @@ import java.time.Duration;
@@ -133,7 +133,7 @@ index a14c3b29b..8edf2910a 100644
    public void should_execute_queries_with_lz4_compression() throws Exception {
      createAndCheckCluster("lz4");
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
-index 8b6526387..4342dbc39 100644
+index 8b65263872..4342dbc391 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
 @@ -43,6 +43,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -153,7 +153,7 @@ index 8b6526387..4342dbc39 100644
    public void should_execute_cas_batch() {
      // Build a batch with CAS operations on the same partition.
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
-index 9e4b62cd2..276be70fb 100644
+index 9e4b62cd23..276be70fb1 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
 @@ -62,6 +62,7 @@ import java.util.Map;
@@ -182,7 +182,7 @@ index 9e4b62cd2..276be70fb 100644
    public void should_set_all_occurrences_of_variable() {
      CqlSession session = sessionRule.session();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
-index 9eb883144..90de52f2c 100644
+index 9eb883144d..90de52f2c0 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
 @@ -40,6 +40,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -239,7 +239,7 @@ index 9eb883144..90de52f2c 100644
    @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
    public void should_reprepare_statement_with_keyspace_on_the_fly() {
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
-index d7e581e46..22891742a 100644
+index d7e581e460..22891742aa 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
 @@ -35,6 +35,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
@@ -260,7 +260,7 @@ index d7e581e46..22891742a 100644
    public void will_cache_invalid_cql() throws Exception {
  
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
-index 5671a7684..88db15ee2 100644
+index 5671a7684e..88db15ee28 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
 @@ -53,6 +53,7 @@ import java.util.concurrent.CompletionStage;
@@ -321,7 +321,7 @@ index 5671a7684..88db15ee2 100644
    @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
    public void should_not_store_metadata_for_conditional_updates_in_legacy_protocol() {
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
-index 37a600efb..74ff340aa 100644
+index 37a600efbc..74ff340aa0 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
 @@ -34,6 +34,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -341,7 +341,7 @@ index 37a600efb..74ff340aa 100644
    public void should_fetch_trace_when_tracing_enabled() {
      ExecutionInfo executionInfo =
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
-index c00cf064e..030300b0d 100644
+index c00cf064e5..030300b0d1 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
 @@ -46,6 +46,7 @@ import java.util.Set;
@@ -369,7 +369,7 @@ index c00cf064e..030300b0d 100644
    public void should_write_batch_cas() {
      BatchStatement batch = createCASBatch();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
-index af454fc64..e3b0e33a6 100644
+index af454fc645..e3b0e33a60 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
 @@ -53,6 +53,7 @@ import java.util.Set;
@@ -390,7 +390,7 @@ index af454fc64..e3b0e33a6 100644
    public void should_apply_node_filter() {
      Set<Node> localNodes = new HashSet<>();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
-index f80b02207..93ede4d1d 100644
+index f80b02207f..93ede4d1dd 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
 @@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -410,7 +410,7 @@ index f80b02207..93ede4d1d 100644
    public void should_expose_metadata_with_correct_case() {
      boolean supportsFunctions = CCM_RULE.getCassandraVersion().compareTo(Version.V2_2_0) >= 0;
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
-index 8f5680ff4..c645f809e 100644
+index 8f5680ff41..c645f809e1 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
 @@ -38,6 +38,7 @@ import java.net.InetSocketAddress;
@@ -440,7 +440,7 @@ index 8f5680ff4..c645f809e 100644
          // CcmBridge does not report accurate C* versions for other distributions (e.g. DSE), only
          // approximated values
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
-index 724508d38..8a85d32bb 100644
+index 724508d38a..8a85d32bbd 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
 @@ -30,6 +30,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -461,7 +461,7 @@ index 724508d38..8a85d32bb 100644
    public void should_fail_on_timeout() {
      CCM_RULE.getCcmBridge().pause(2);
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
-index 85fcfc02c..17e4d2595 100644
+index 85fcfc02cd..17e4d25952 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 @@ -47,6 +47,7 @@ import java.util.function.Consumer;
@@ -547,7 +547,7 @@ index 85fcfc02c..17e4d2595 100644
    public void should_handle_aggregate_update() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
-index df5571974..317422e06 100644
+index df5571974c..317422e06e 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
 @@ -47,6 +47,7 @@ import java.util.Map;
@@ -574,8 +574,32 @@ index df5571974..317422e06 100644
    @BackendRequirement(
        type = BackendType.CASSANDRA,
        minInclusive = "4.0",
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+index e0184516e2..c0c086179c 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.core.metrics.Metrics;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+ import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+ import java.util.ArrayList;
+ import java.util.List;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class DropwizardMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
-index 1ce3fd1ca..fdd2ea861 100644
+index 1ce3fd1ca0..fdd2ea8617 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
 @@ -33,6 +33,7 @@ import java.util.Map;
@@ -595,7 +619,7 @@ index 1ce3fd1ca..fdd2ea861 100644
    public void should_signal_and_create_pool_when_node_gets_added() {
      AddListener addListener = new AddListener();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
-index e0f332915..66a3d81fc 100644
+index e0f3329154..66a3d81fc8 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
 @@ -33,6 +33,7 @@ import java.util.Map;
@@ -616,7 +640,7 @@ index e0f332915..66a3d81fc 100644
    public void should_signal_and_destroy_pool_when_node_gets_removed() {
      RemovalListener removalListener = new RemovalListener();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
-index c6e909122..ddaf74f07 100644
+index c6e9091220..ddaf74f07c 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
 @@ -54,6 +54,7 @@ import java.util.stream.Stream;
@@ -643,7 +667,7 @@ index c6e909122..ddaf74f07 100644
    public void should_execute_async_conditional_query_and_map_to_boolean() {
      assertThat(CompletableFutures.getUninterruptibly(dao.deleteIfExistsAsync(1, 1))).isTrue();
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
-index 3eb40fd85..df1a5e40b 100644
+index 3eb40fd852..df1a5e40be 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
 @@ -46,6 +46,7 @@ import java.util.Map;
@@ -663,8 +687,56 @@ index 3eb40fd85..df1a5e40b 100644
    @Test
    public void should_select_with_per_partition_limit() {
      PagingIterable<Simple> elements = dao.selectWithPerPartitionLimit(5);
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+index c38df1e202..29479f27ee 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -40,9 +39,9 @@ import io.micrometer.core.instrument.Tag;
+ import io.micrometer.core.instrument.Timer;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicrometerMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+index aa04c058a4..5d0a67f8aa 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
+ import org.eclipse.microprofile.metrics.Tag;
+ import org.eclipse.microprofile.metrics.Timer;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicroProfileMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/test-infra/revapi.json b/test-infra/revapi.json
-index c75a98cb4..366049236 100644
+index c75a98cb4a..3660492368 100644
 --- a/test-infra/revapi.json
 +++ b/test-infra/revapi.json
 @@ -192,6 +192,16 @@
@@ -685,7 +757,7 @@ index c75a98cb4..366049236 100644
      ]
    }
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
-index 882cd55b9..8baa4edf9 100644
+index 882cd55b94..8baa4edf9a 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 @@ -20,9 +20,14 @@ package com.datastax.oss.driver.api.testinfra.ccm;
@@ -718,7 +790,7 @@ index 882cd55b9..8baa4edf9 100644
    public Statement apply(Statement base, Description description) {
      if (BackendRequirementRule.meetsDescriptionRequirements(description)) {
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
-index f0ce6bc5b..e76d46b11 100644
+index f0ce6bc5b0..e76d46b114 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 @@ -61,6 +61,10 @@ public class CcmBridge implements AutoCloseable {
@@ -862,7 +934,7 @@ index f0ce6bc5b..e76d46b11 100644
            dseConfiguration,
            dseRawYaml,
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
-index 5ea1bf7ed..1e26ec468 100644
+index 5ea1bf7ed3..1e26ec4682 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 @@ -17,6 +17,7 @@
@@ -906,7 +978,7 @@ index 5ea1bf7ed..1e26ec468 100644
        return new CustomCcmRule(bridgeBuilder.build());
      }
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
-index 0819f7854..16c88c43a 100644
+index 0819f78544..16c88c43ad 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
 @@ -28,12 +28,13 @@ public class DefaultCcmBridgeBuilderCustomizer {

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -1,5 +1,5 @@
 diff --git a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
-index 7d90c5002..68e59e89c 100644
+index 7d90c50028..68e59e89c3 100644
 --- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
 +++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/DriverBlockHoundIntegration.java
 @@ -107,5 +107,11 @@ public final class DriverBlockHoundIntegration implements BlockHoundIntegration
@@ -15,7 +15,7 @@ index 7d90c5002..68e59e89c 100644
    }
  }
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
-index d70c6d3fa..c9839c3b9 100644
+index d70c6d3fac..c9839c3b93 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
 @@ -29,6 +29,7 @@ import com.datastax.oss.simulacron.common.cluster.QueryLog;
@@ -49,10 +49,10 @@ index d70c6d3fa..c9839c3b9 100644
    public void should_successfully_send_peers_v2_node_refresh_query()
        throws InterruptedException, ExecutionException {
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
-index 13405804a..c34d0739f 100644
+index ca421d1ad4..a665f75b33 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
-@@ -42,7 +42,7 @@ public class ZeroTokenNodesIT {
+@@ -44,7 +44,7 @@ public class ZeroTokenNodesIT {
    public void should_not_ignore_zero_token_peer_when_option_is_enabled() {
      CqlSession session = null;
      CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
@@ -61,7 +61,7 @@ index 13405804a..c34d0739f 100644
        ccmBridge.create();
        ccmBridge.startWithArgs("--wait-for-binary-proto");
        ccmBridge.addWithoutStart(4, "dc1");
-@@ -72,7 +72,7 @@ public class ZeroTokenNodesIT {
+@@ -74,7 +74,7 @@ public class ZeroTokenNodesIT {
    public void should_not_discover_zero_token_DC_when_option_is_disabled() {
      CqlSession session = null;
      CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
@@ -70,7 +70,7 @@ index 13405804a..c34d0739f 100644
        ccmBridge.create();
        ccmBridge.updateNodeConfig(3, "join_ring", false);
        ccmBridge.updateNodeConfig(4, "join_ring", false);
-@@ -109,7 +109,7 @@ public class ZeroTokenNodesIT {
+@@ -111,7 +111,7 @@ public class ZeroTokenNodesIT {
    public void should_discover_zero_token_DC_when_option_is_enabled() {
      CqlSession session = null;
      CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
@@ -79,7 +79,7 @@ index 13405804a..c34d0739f 100644
        ccmBridge.create();
        ccmBridge.updateNodeConfig(3, "join_ring", false);
        ccmBridge.updateNodeConfig(4, "join_ring", false);
-@@ -150,7 +150,7 @@ public class ZeroTokenNodesIT {
+@@ -152,7 +152,7 @@ public class ZeroTokenNodesIT {
    public void should_connect_to_zero_token_contact_point() {
      CqlSession session = null;
      CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
@@ -88,7 +88,7 @@ index 13405804a..c34d0739f 100644
        ccmBridge.create();
        ccmBridge.startWithArgs("--wait-for-binary-proto");
        ccmBridge.addWithoutStart(3, "dc1");
-@@ -180,7 +180,7 @@ public class ZeroTokenNodesIT {
+@@ -182,7 +182,7 @@ public class ZeroTokenNodesIT {
      // method.
      CqlSession session = null;
      CcmBridge.Builder ccmBridgeBuilder = CcmBridge.builder();
@@ -97,8 +97,32 @@ index 13405804a..c34d0739f 100644
        ccmBridge.create();
        ccmBridge.updateNodeConfig(3, "join_ring", false);
        ccmBridge.updateNodeConfig(4, "join_ring", false);
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+index e0184516e2..c0c086179c 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.core.metrics.Metrics;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+ import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+ import java.util.ArrayList;
+ import java.util.List;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class DropwizardMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
-index 93ecbf181..ead5bd54d 100644
+index 1cff5d998a..5fe8d51bf9 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 @@ -63,7 +63,7 @@ public class MockResolverIT {
@@ -167,8 +191,58 @@ index 93ecbf181..ead5bd54d 100644
        MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
        MultimapHostResolverProvider.addResolverEntry(
            "test.cluster.fake", ccmBridge.getNodeIpAddress(1));
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+index ef87040f2a..29479f27ee 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -40,11 +39,9 @@ import io.micrometer.core.instrument.Tag;
+ import io.micrometer.core.instrument.Timer;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import org.junit.ClassRule;
+-import org.junit.Ignore;
+-import org.junit.experimental.categories.Category;
+ 
+-@Ignore("@IntegrationTestDisabledFlaky")
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicrometerMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+index aa04c058a4..5d0a67f8aa 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
+ import org.eclipse.microprofile.metrics.Tag;
+ import org.eclipse.microprofile.metrics.Timer;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicroProfileMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
-index 2e137b085..6c311cd4f 100644
+index 2e137b0854..6c311cd4f2 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 @@ -26,13 +26,18 @@ package com.datastax.oss.driver.api.testinfra.ccm;
@@ -209,15 +283,15 @@ index 7b4d28cedf..2c8edd1e5a 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
 @@ -68,6 +68,10 @@ public class CcmBridge implements AutoCloseable {
-
+ 
    public static final Version VERSION = Objects.requireNonNull(parseCcmVersion());
-
+ 
 +  public String idPrefix = "0";
 +
 +  public static final String SCYLLA_VERSION = System.getProperty("scylla.version");
 +
    public static final String INSTALL_DIRECTORY = System.getProperty("ccm.directory");
-
+ 
    public static final String BRANCH = System.getProperty("ccm.branch");
 @@ -175,7 +179,6 @@ public class CcmBridge implements AutoCloseable {
    private final Path configDirectory;
@@ -258,7 +332,7 @@ index 7b4d28cedf..2c8edd1e5a 100644
            createOptions.stream().collect(Collectors.joining(" ")));
 @@ -492,7 +495,8 @@ public class CcmBridge implements AutoCloseable {
    }
-
+ 
    public void addWithoutStart(int n, String dc) {
 -    String[] initialArgs = new String[] {"add", "-i", ipPrefix + n, "-d", dc, "node" + n};
 +    String[] initialArgs =
@@ -268,12 +342,12 @@ index 7b4d28cedf..2c8edd1e5a 100644
        args.add("--dse");
 @@ -617,7 +621,7 @@ public class CcmBridge implements AutoCloseable {
    }
-
+ 
    public String getNodeIpAddress(int nodeId) {
 -    return ipPrefix + nodeId;
 +    return "127.0." + idPrefix + "." + nodeId;
    }
-
+ 
    private static String IN_MS_STR = "_in_ms";
 @@ -664,7 +668,7 @@ public class CcmBridge implements AutoCloseable {
      private final Map<String, Object> dseConfiguration = new LinkedHashMap<>();
@@ -283,18 +357,18 @@ index 7b4d28cedf..2c8edd1e5a 100644
 +    private String idPrefix = "0";
      private final List<String> createOptions = new ArrayList<>();
      private final List<String> dseWorkloads = new ArrayList<>();
-
+ 
 @@ -708,8 +712,8 @@ public class CcmBridge implements AutoCloseable {
        return this;
      }
-
+ 
 -    public Builder withIpPrefix(String ipPrefix) {
 -      this.ipPrefix = ipPrefix;
 +    public Builder withIdPrefix(String idPrefix) {
 +      this.idPrefix = idPrefix;
        return this;
      }
-
+ 
 @@ -778,7 +782,7 @@ public class CcmBridge implements AutoCloseable {
        return new CcmBridge(
            configDirectory,
@@ -305,7 +379,7 @@ index 7b4d28cedf..2c8edd1e5a 100644
            dseConfiguration,
            dseRawYaml,
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
-index 79cc0f7e6..6240cc58b 100644
+index 79cc0f7e60..6240cc58ba 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 @@ -17,6 +17,7 @@

--- a/versions/scylla/4.19.0.0/patch
+++ b/versions/scylla/4.19.0.0/patch
@@ -97,6 +97,30 @@ index ca421d1ad4..a665f75b33 100644
        ccmBridge.create();
        ccmBridge.updateNodeConfig(3, "join_ring", false);
        ccmBridge.updateNodeConfig(4, "join_ring", false);
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+index e0184516e2..c0c086179c 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.core.metrics.Metrics;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+ import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+ import java.util.ArrayList;
+ import java.util.List;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class DropwizardMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 index 1cff5d998a..5fe8d51bf9 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
@@ -167,6 +191,56 @@ index 1cff5d998a..5fe8d51bf9 100644
        MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
        MultimapHostResolverProvider.addResolverEntry(
            "test.cluster.fake", ccmBridge.getNodeIpAddress(1));
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+index ef87040f2a..29479f27ee 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -40,11 +39,9 @@ import io.micrometer.core.instrument.Tag;
+ import io.micrometer.core.instrument.Timer;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import org.junit.ClassRule;
+-import org.junit.Ignore;
+-import org.junit.experimental.categories.Category;
+ 
+-@Ignore("@IntegrationTestDisabledFlaky")
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicrometerMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+index aa04c058a4..5d0a67f8aa 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
+ import org.eclipse.microprofile.metrics.Tag;
+ import org.eclipse.microprofile.metrics.Timer;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicroProfileMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 index 8d27502eab..715379224e 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java


### PR DESCRIPTION
Backports fix to metrics ITs that makes them serial instead. Those tests interfere with each other when run concurrently.

See commit e2533ea76b2aa61e629e841facca1c2f653dac1f in scylladb/java-driver for more details.