### PR TITLE
scripts: bake ruamel.yaml into Docker image, bump tag to 20260402

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -33,4 +33,5 @@ RUN echo 2 | update-alternatives --config java
 
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
+RUN pip install ruamel.yaml
 

--- a/scripts/image
+++ b/scripts/image
@@ -1,1 +1,1 @@
-scylladb/scylla-cassandra-unit-tests:java-matrix-driver-20250704
+scylladb/scylla-cassandra-unit-tests:java-matrix-driver-20260402


### PR DESCRIPTION
## Problem

All `scylla-2025.1` CI builds (#22–#25) fail immediately with:

```
pkg_resources.DistributionNotFound: The 'ruamel.yaml' distribution was not found and is required by ccm
```

**Root cause:** The `ccm` entrypoint script generated by the old `setuptools` in the Docker image uses `pkg_resources.require('ccm==2.0.5')`. `pkg_resources` only scans the system site-packages (`/usr/local/lib/python3.11/site-packages/`). However, `run_test.sh` installs `scylla-ccm` with `pip install --user -e`, which places `ruamel.yaml` (a `scylla-ccm` dependency) in `~/.local/lib/python3.11/site-packages/`. Since `pkg_resources` never sees that path, every `ccm` invocation fails before doing anything.

## Fix

- **`scripts/Dockerfile`**: add `RUN pip install ruamel.yaml` — installs `ruamel.yaml` into the system site-packages at image build time, making it visible to `pkg_resources` at runtime regardless of how `ccm` itself is installed.
- **`scripts/image`**: bump tag from `java-matrix-driver-20250704` to `java-matrix-driver-20260402` to reference the rebuilt image.

## Action required after merge

The new image must be built and pushed to Docker Hub:

```bash
export UNIT_TEST_DOCKER_IMAGE=scylladb/scylla-cassandra-unit-tests:java-matrix-driver-20260402
docker build ./scripts/ -t ${UNIT_TEST_DOCKER_IMAGE}
docker push ${UNIT_TEST_DOCKER_IMAGE}
```

(As documented in `README.md` under "Uploading docker images".)