### PR TITLE
fix: replace SimpleStrategy with NetworkTopologyStrategy in patches

### DIFF
--- a/versions/datastax/4.19.1/patch
+++ b/versions/datastax/4.19.1/patch
@@ -461,7 +461,7 @@ index 724508d38..8a85d32bb 100644
    public void should_fail_on_timeout() {
      CCM_RULE.getCcmBridge().pause(2);
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
-index 85fcfc02c..17e4d2595 100644
+index 85fcfc02c..e1dab54de 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 @@ -47,6 +47,7 @@ import java.util.function.Consumer;
@@ -472,7 +472,50 @@ index 85fcfc02c..17e4d2595 100644
  import org.junit.Test;
  import org.junit.rules.RuleChain;
  import org.junit.rules.TestRule;
-@@ -260,8 +261,9 @@ public class SchemaChangesIT {
+@@ -93,16 +94,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -115,7 +115,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -130,11 +130,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -260,8 +260,9 @@ public class SchemaChangesIT {
            assertThat(view.getName().asInternal()).isEqualTo("highscores");
            assertThat(view.getBaseTable().asInternal()).isEqualTo("scores");
            assertThat(view.includesAllColumns()).isFalse();
@@ -484,7 +527,7 @@ index 85fcfc02c..17e4d2595 100644
            assertThat(view.getColumns())
                .containsOnlyKeys(
                    CqlIdentifier.fromInternal("game"),
-@@ -271,6 +273,7 @@ public class SchemaChangesIT {
+@@ -271,6 +272,7 @@ public class SchemaChangesIT {
          (listener, view) -> verify(listener).onViewCreated(view));
    }
  
@@ -492,7 +535,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_view_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V3_0_0) >= 0)
-@@ -314,6 +317,8 @@ public class SchemaChangesIT {
+@@ -314,6 +316,8 @@ public class SchemaChangesIT {
          (listener, oldView, newView) -> verify(listener).onViewUpdated(newView, oldView));
    }
  
@@ -501,7 +544,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_creation() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -338,6 +343,8 @@ public class SchemaChangesIT {
+@@ -338,6 +342,8 @@ public class SchemaChangesIT {
          (listener, function) -> verify(listener).onFunctionCreated(function));
    }
  
@@ -510,7 +553,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -354,6 +361,8 @@ public class SchemaChangesIT {
+@@ -354,6 +360,8 @@ public class SchemaChangesIT {
          (listener, oldFunction) -> verify(listener).onFunctionDropped(oldFunction));
    }
  
@@ -519,7 +562,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_update() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -374,6 +383,8 @@ public class SchemaChangesIT {
+@@ -374,6 +382,8 @@ public class SchemaChangesIT {
              verify(listener).onFunctionUpdated(newFunction, oldFunction));
    }
  
@@ -528,7 +571,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_aggregate_creation() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -400,6 +411,8 @@ public class SchemaChangesIT {
+@@ -400,6 +410,8 @@ public class SchemaChangesIT {
          (listener, aggregate) -> verify(listener).onAggregateCreated(aggregate));
    }
  
@@ -537,7 +580,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_aggregate_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -417,6 +430,8 @@ public class SchemaChangesIT {
+@@ -417,6 +429,8 @@ public class SchemaChangesIT {
          (listener, oldAggregate) -> verify(listener).onAggregateDropped(oldAggregate));
    }
  
@@ -574,6 +617,23 @@ index df5571974..317422e06 100644
    @BackendRequirement(
        type = BackendType.CASSANDRA,
        minInclusive = "4.0",
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index 057461a1b..393b968cd 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
 index e0184516e..c0c086179 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
@@ -639,6 +699,32 @@ index e0f332915..66a3d81fc 100644
    @Test
    public void should_signal_and_destroy_pool_when_node_gets_removed() {
      RemovalListener removalListener = new RemovalListener();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87..376834519 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363..06810507e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
 index c6e909122..ddaf74f07 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
@@ -999,3 +1085,16 @@ index 0819f7854..16c88c43a 100644
        builder.withCassandraConfiguration("num_tokens", "1");
        builder.withCassandraConfiguration("initial_token", "0");
      }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffd..6e13cc5cf 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();

--- a/versions/datastax/4.19.2/patch
+++ b/versions/datastax/4.19.2/patch
@@ -461,7 +461,7 @@ index 724508d38..8a85d32bb 100644
    public void should_fail_on_timeout() {
      CCM_RULE.getCcmBridge().pause(2);
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
-index 85fcfc02c..17e4d2595 100644
+index 85fcfc02c..e1dab54de 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
 @@ -47,6 +47,7 @@ import java.util.function.Consumer;
@@ -472,7 +472,50 @@ index 85fcfc02c..17e4d2595 100644
  import org.junit.Test;
  import org.junit.rules.RuleChain;
  import org.junit.rules.TestRule;
-@@ -260,8 +261,9 @@ public class SchemaChangesIT {
+@@ -93,16 +94,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -115,7 +115,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -130,11 +130,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -260,8 +260,9 @@ public class SchemaChangesIT {
            assertThat(view.getName().asInternal()).isEqualTo("highscores");
            assertThat(view.getBaseTable().asInternal()).isEqualTo("scores");
            assertThat(view.includesAllColumns()).isFalse();
@@ -484,7 +527,7 @@ index 85fcfc02c..17e4d2595 100644
            assertThat(view.getColumns())
                .containsOnlyKeys(
                    CqlIdentifier.fromInternal("game"),
-@@ -271,6 +273,7 @@ public class SchemaChangesIT {
+@@ -271,6 +272,7 @@ public class SchemaChangesIT {
          (listener, view) -> verify(listener).onViewCreated(view));
    }
  
@@ -492,7 +535,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_view_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V3_0_0) >= 0)
-@@ -314,6 +317,8 @@ public class SchemaChangesIT {
+@@ -314,6 +316,8 @@ public class SchemaChangesIT {
          (listener, oldView, newView) -> verify(listener).onViewUpdated(newView, oldView));
    }
  
@@ -501,7 +544,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_creation() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -338,6 +343,8 @@ public class SchemaChangesIT {
+@@ -338,6 +342,8 @@ public class SchemaChangesIT {
          (listener, function) -> verify(listener).onFunctionCreated(function));
    }
  
@@ -510,7 +553,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -354,6 +361,8 @@ public class SchemaChangesIT {
+@@ -354,6 +360,8 @@ public class SchemaChangesIT {
          (listener, oldFunction) -> verify(listener).onFunctionDropped(oldFunction));
    }
  
@@ -519,7 +562,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_function_update() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -374,6 +383,8 @@ public class SchemaChangesIT {
+@@ -374,6 +382,8 @@ public class SchemaChangesIT {
              verify(listener).onFunctionUpdated(newFunction, oldFunction));
    }
  
@@ -528,7 +571,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_aggregate_creation() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -400,6 +411,8 @@ public class SchemaChangesIT {
+@@ -400,6 +410,8 @@ public class SchemaChangesIT {
          (listener, aggregate) -> verify(listener).onAggregateCreated(aggregate));
    }
  
@@ -537,7 +580,7 @@ index 85fcfc02c..17e4d2595 100644
    @Test
    public void should_handle_aggregate_drop() {
      assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
-@@ -417,6 +430,8 @@ public class SchemaChangesIT {
+@@ -417,6 +429,8 @@ public class SchemaChangesIT {
          (listener, oldAggregate) -> verify(listener).onAggregateDropped(oldAggregate));
    }
  
@@ -574,6 +617,23 @@ index df5571974..317422e06 100644
    @BackendRequirement(
        type = BackendType.CASSANDRA,
        minInclusive = "4.0",
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index 057461a1b..393b968cd 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
 index e0184516e..c0c086179 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
@@ -639,6 +699,32 @@ index e0f332915..66a3d81fc 100644
    @Test
    public void should_signal_and_destroy_pool_when_node_gets_removed() {
      RemovalListener removalListener = new RemovalListener();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87..376834519 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363..06810507e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
 index c6e909122..ddaf74f07 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
@@ -999,3 +1085,16 @@ index 0819f7854..16c88c43a 100644
        builder.withCassandraConfiguration("num_tokens", "1");
        builder.withCassandraConfiguration("initial_token", "0");
      }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffd..6e13cc5cf 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();

--- a/versions/scylla/3.11.4.0/patch
+++ b/versions/scylla/3.11.4.0/patch
@@ -353,7 +353,7 @@ index 7fa9c8550a..9ac6b9135e 100644
      session.execute(
 -        "create keyspace ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
 -    session.execute("create type ks.foo (i int)");
-+        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
 +    session.execute("create type ControlConnectionTest_ks.foo (i int)");
      cluster.close();
  
@@ -742,3 +742,166 @@ index 777ea439f8..a63e169dac 100644
      assertThat(table.getColumns().get(0)).isNotNull().hasName("k").isPartitionKey().hasType(text());
      assertThat(table.getColumns().get(1))
          .isNotNull()
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+index b1867a0562..ac36feb518 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+@@ -95,7 +95,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
+     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
+     session()
+         .execute(
+-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
++            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
+     session()
+         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+index 5dea37b8e2..157e59e4b1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+@@ -86,7 +86,7 @@ public abstract class TestUtils {
+   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
+ 
+   public static final String CREATE_KEYSPACE_SIMPLE_FORMAT =
+-      "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }";
++      "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : %d }";
+   public static final String CREATE_KEYSPACE_GENERIC_FORMAT =
+       "CREATE KEYSPACE %s WITH replication = { 'class' : '%s', %s }";
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+index 098164caa8..bb69af8a3b 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+@@ -62,7 +62,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
+       String keyspace = (String) objects[0];
+       execute(
+           String.format(
+-              "create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++              "create keyspace %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
+               keyspace),
+           String.format("create table %s.foo(k int, v int, primary key (k, v))", keyspace));
+       for (int v = 1; v <= 100; v++)
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+index 26e88c5d87..f3180ab1a3 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+@@ -63,7 +63,7 @@ public class MetadataTest extends CCMTestsSupport {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     Metadata metadata = cluster.getMetadata();
+ 
+     // Capture all Token data.
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+index c2575b0e2c..8a246f7e4b 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+@@ -77,10 +77,10 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
+     ks2 = TestUtils.generateIdentifier("ks_");
+     execute(
+         String.format(
+-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
+             ks1),
+         String.format(
+-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}",
+             ks2),
+         String.format("USE %s", ks1),
+         "CREATE TABLE foo(i int primary key)",
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+index f37d2dcce5..1e44f859bc 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+@@ -100,7 +100,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type");
+     session()
+         .execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<tuple<ascii, int, boolean>>)");
+@@ -169,7 +169,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type_varying_lengths "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type_varying_lengths");
+ 
+     // programmatically create the table with tuples of said sizes
+@@ -226,7 +226,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_subtypes");
+ 
+     // programmatically create the table with a tuple of all datatypes
+@@ -294,7 +294,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_non_primitive_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_non_primitive_subtypes");
+ 
+     ArrayList<String> values = new ArrayList<String>();
+@@ -471,7 +471,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_nested_tuples "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_nested_tuples");
+ 
+     // create a table with multiple sizes of nested tuples
+@@ -519,7 +519,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE testTuplesWithNulls "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE testTuplesWithNulls");
+ 
+     // create UDT
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+index eb9faa0392..2986987915 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+@@ -34,7 +34,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+   private static final String EXPECTED_SCHEMA =
+       String.format(
+-          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;\n"
++          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '1' } AND DURABLE_WRITES = true;\n"
+               + "\n"
+               + "CREATE TYPE %s.g (\n"
+               + "    f1 int\n"
+@@ -89,7 +89,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+          Topological sort order should be : gh,FE,D,CB,A
+          */
+-        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
++        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'}",
+         String.format("CREATE TYPE %s.h (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.g (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", KEYSPACE),
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+index 42a352c703..7c48652e7c 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+@@ -150,7 +150,7 @@ public class UserTypesTest extends CCMTestsSupport {
+             "CREATE KEYSPACE "
+                 + otherKeyspaceName
+                 + " "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+ 
+     KeyspaceMetadata otherKeyspace = cluster().getMetadata().getKeyspace(otherKeyspaceName);
+     assertThat(otherKeyspace.getUserType(quote("\"User Address\""))).isNull();
+

--- a/versions/scylla/3.11.5.14/ignore.yaml
+++ b/versions/scylla/3.11.5.14/ignore.yaml
@@ -1,0 +1,20 @@
+tests:
+  # test count on tracing which it's content is different in scylla, should be skipped on scylla
+  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+
+  # disable cause now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest
+
+  # using 2 node cluster, and stopping one, isn't supported by scylla since raft
+  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest
+
+  # scylla-ccm no longer supports --sni-proxy option
+  - ScyllaSniProxyTest
+
+  # node stop/start sequence causes Scylla to fail to open its binary port within the 5-minute
+  # CCM timeout, likely due to timing differences vs Cassandra in this driver version
+  - NodeRefreshDebouncerTest #should_call_onAdd_with_bootstrap_stop_start

--- a/versions/scylla/3.11.5.14/ignore.yaml
+++ b/versions/scylla/3.11.5.14/ignore.yaml
@@ -1,0 +1,20 @@
+tests:
+  # test count on tracing which its content is different in scylla, should be skipped on scylla
+  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+
+  # disable because now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest
+
+  # using 2 node cluster, and stopping one, isn't supported by scylla since raft
+  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest
+
+  # scylla-ccm no longer supports --sni-proxy option
+  - ScyllaSniProxyTest
+
+  # node stop/start sequence causes Scylla to fail to open its binary port within the 5-minute
+  # CCM timeout, likely due to timing differences vs Cassandra in this driver version
+  - NodeRefreshDebouncerTest #should_call_onAdd_with_bootstrap_stop_start

--- a/versions/scylla/3.11.5.14/patch
+++ b/versions/scylla/3.11.5.14/patch
@@ -1,0 +1,323 @@
+diff --git a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+index f03e617b20..ca1cd2ca2c 100644
+--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
++++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+@@ -607,9 +607,8 @@ public class Metadata {
+       if (keyspace != null && table != null) {
+         assert (token instanceof Token.TokenLong64);
+         return tabletMap.getReplicas(keyspace, table, (long) token.getValue());
+-      } else {
+-        return EMPTY_LIST;
+       }
++      // table == null: caller opted out of tablet-specific lookup; fall back to token map
+     }
+ 
+     // TokenMap:
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+index d8e869ff45..440f91994b 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+@@ -64,7 +64,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
+       String keyspace = (String) objects[0];
+       execute(
+           String.format(
+-              "create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++              "create keyspace %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
+               keyspace),
+           String.format("create table %s.foo(k int, v int, primary key (k, v))", keyspace));
+       for (int v = 1; v <= 100; v++)
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+index 344678c814..74a126cb20 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+@@ -207,11 +207,11 @@ public class CCMBridge implements CCMAccess {
+       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
+     } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+       installArgs.add(" --scylla ");
+-      if (isVersionNumber(inputScyllaVersion)) {
+-        installArgs.add("-v release:" + inputScyllaVersion);
+-      } else {
+-        installArgs.add("-v " + inputScyllaVersion);
+-      }
++      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
++      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
++      // proven difficult.
++      installArgs.add("-v " + inputScyllaVersion);
++
+       // Detect Scylla Enterprise - it should start with
+       // a 4-digit year.
+       if (inputScyllaVersion.matches("\\d{4}\\..*")) {
+@@ -480,10 +480,14 @@ public class CCMBridge implements CCMAccess {
+ 
+   @Override
+   public InetSocketAddress jmxAddressOfNode(int n) {
++    // For dynamically added nodes (via add()), jmxPorts[] may not have an entry since it is
++    // sized only for nodes declared at cluster-creation time. Fall back to the same deterministic
++    // formula used in add().
++    int port = (n - 1 < jmxPorts.length) ? jmxPorts[n - 1] : (7000 + n * 100);
+     if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+-      return new InetSocketAddress(ipOfNode(n), jmxPorts[n - 1]);
++      return new InetSocketAddress(ipOfNode(n), port);
+     } else {
+-      return new InetSocketAddress("localhost", jmxPorts[n - 1]);
++      return new InetSocketAddress("localhost", port);
+     }
+   }
+ 
+@@ -733,23 +737,25 @@ public class CCMBridge implements CCMAccess {
+   public void add(int dc, int n) {
+     logger.debug(
+         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
+-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
+     String storageItf = ipOfNode(n) + ":" + storagePort;
+     String binaryItf = ipOfNode(n) + ":" + binaryPort;
+     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
++    // Use a deterministic JMX port formula to avoid TOCTOU races from findAvailablePort()
++    // and to match the fallback in jmxAddressOfNode() for dynamically added nodes (jmxPorts[]
++    // is sized only for nodes declared at cluster-creation time).
++    int jmxPort = 7000 + n * 100;
+     execute(
+         CCM_COMMAND
+-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
++            + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b"
+             + (isDSE ? " --dse" : "")
+             + (isScylla ? " --scylla" : ""),
+         n,
+         dc,
+         ipPrefix,
+         n,
+-        thriftItf,
+         storageItf,
+         binaryItf,
+-        TestUtils.findAvailablePort(),
++        jmxPort,
+         remoteLogItf);
+   }
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+index a925ecbb86..2670c2022d 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+@@ -119,7 +119,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
+     Cluster cluster = register(createClusterBuilder().build());
+     Session session = cluster.connect();
+     session.execute(
+-        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     session.execute("create type ControlConnectionTest_ks.foo (i int)");
+     cluster.close();
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+index 26e88c5d87..f3180ab1a3 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+@@ -63,7 +63,7 @@ public class MetadataTest extends CCMTestsSupport {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     Metadata metadata = cluster.getMetadata();
+ 
+     // Capture all Token data.
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+index 25bb3267cf..9d4bdd3da1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+@@ -482,7 +482,7 @@ public class PreparedStatementInvalidationTest extends CCMTestsSupport {
+             .init();
+     Session session = cluster.connect();
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }");
++        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1' }");
+     session.execute("USE cql4_loopholes_test");
+     return session;
+   }
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+index ea75f84544..ea70e9081a 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
+-@CCMConfig(dirtiesContext = true)
++@CCMConfig(
++    dirtiesContext = true,
++    jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"})
+ public class SessionStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+index b1867a0562..ac36feb518 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+@@ -95,7 +95,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
+     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
+     session()
+         .execute(
+-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
++            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
+     session()
+         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java b/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
+index 28e42df83b..65922dfde0 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
+@@ -8,7 +8,7 @@ public class StatementPagesTest extends CCMTestsSupport {
+   @Override
+   public void onTestContextInitialized() {
+     execute(
+-        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     execute("CREATE TABLE IF NOT EXISTS ks.t (pk int, ck int, v int, PRIMARY KEY(pk, ck))");
+ 
+     for (int i = 0; i < 50; i++) {
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+index 5dea37b8e2..157e59e4b1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+@@ -86,7 +86,7 @@ public abstract class TestUtils {
+   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
+ 
+   public static final String CREATE_KEYSPACE_SIMPLE_FORMAT =
+-      "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }";
++      "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : %d }";
+   public static final String CREATE_KEYSPACE_GENERIC_FORMAT =
+       "CREATE KEYSPACE %s WITH replication = { 'class' : '%s', %s }";
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+index 61412768bc..13ff456a0f 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+@@ -77,10 +77,10 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
+     ks2 = TestUtils.generateIdentifier("ks_");
+     execute(
+         String.format(
+-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
+             ks1),
+         String.format(
+-            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}",
+             ks2),
+         String.format("USE %s", ks1),
+         "CREATE TABLE foo(i int primary key)",
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+index f37d2dcce5..1e44f859bc 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+@@ -100,7 +100,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type");
+     session()
+         .execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<tuple<ascii, int, boolean>>)");
+@@ -169,7 +169,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type_varying_lengths "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type_varying_lengths");
+ 
+     // programmatically create the table with tuples of said sizes
+@@ -226,7 +226,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_subtypes");
+ 
+     // programmatically create the table with a tuple of all datatypes
+@@ -294,7 +294,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_non_primitive_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_non_primitive_subtypes");
+ 
+     ArrayList<String> values = new ArrayList<String>();
+@@ -471,7 +471,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_nested_tuples "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_nested_tuples");
+ 
+     // create a table with multiple sizes of nested tuples
+@@ -519,7 +519,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE testTuplesWithNulls "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE testTuplesWithNulls");
+ 
+     // create UDT
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+index eb9faa0392..2986987915 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+@@ -34,7 +34,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+   private static final String EXPECTED_SCHEMA =
+       String.format(
+-          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;\n"
++          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '1' } AND DURABLE_WRITES = true;\n"
+               + "\n"
+               + "CREATE TYPE %s.g (\n"
+               + "    f1 int\n"
+@@ -89,7 +89,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+          Topological sort order should be : gh,FE,D,CB,A
+          */
+-        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
++        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'}",
+         String.format("CREATE TYPE %s.h (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.g (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", KEYSPACE),
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+index 42a352c703..7c48652e7c 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+@@ -150,7 +150,7 @@ public class UserTypesTest extends CCMTestsSupport {
+             "CREATE KEYSPACE "
+                 + otherKeyspaceName
+                 + " "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+ 
+     KeyspaceMetadata otherKeyspace = cluster().getMetadata().getKeyspace(otherKeyspaceName);
+     assertThat(otherKeyspace.getUserType(quote("\"User Address\""))).isNull();
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+index eeb57e91b2..acc44b2c51 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+@@ -22,7 +22,6 @@
+ package com.datastax.driver.core.policies;
+ 
+ import static com.datastax.driver.core.Assertions.assertThat;
+-import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
+ import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
+ import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.NEUTRAL;
+ import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.RANDOM;
+@@ -980,7 +979,10 @@ public class TokenAwarePolicyTest {
+       Session session = cluster.connect();
+ 
+       String ks = TestUtils.generateIdentifier("ks_");
+-      session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, 1));
++      session.execute(
++          String.format(
++              "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false}",
++              ks));
+       session.execute("USE " + ks);
+       session.execute("CREATE TABLE composite (k1 int, k2 int, i int, PRIMARY KEY ((k1, k2)))");
+ 

--- a/versions/scylla/3.11.5.14/patch
+++ b/versions/scylla/3.11.5.14/patch
@@ -1,0 +1,380 @@
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+index d8e869ff45..440f91994b 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+@@ -64,7 +64,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
+       String keyspace = (String) objects[0];
+       execute(
+           String.format(
+-              "create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++              "create keyspace %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}",
+               keyspace),
+           String.format("create table %s.foo(k int, v int, primary key (k, v))", keyspace));
+       for (int v = 1; v <= 100; v++)
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+index 344678c814..74a126cb20 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+@@ -207,11 +207,11 @@ public class CCMBridge implements CCMAccess {
+       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
+     } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+       installArgs.add(" --scylla ");
+-      if (isVersionNumber(inputScyllaVersion)) {
+-        installArgs.add("-v release:" + inputScyllaVersion);
+-      } else {
+-        installArgs.add("-v " + inputScyllaVersion);
+-      }
++      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
++      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
++      // proven difficult.
++      installArgs.add("-v " + inputScyllaVersion);
++
+       // Detect Scylla Enterprise - it should start with
+       // a 4-digit year.
+       if (inputScyllaVersion.matches("\\d{4}\\..*")) {
+@@ -480,10 +480,14 @@ public class CCMBridge implements CCMAccess {
+ 
+   @Override
+   public InetSocketAddress jmxAddressOfNode(int n) {
++    // For dynamically added nodes (via add()), jmxPorts[] may not have an entry since it is
++    // sized only for nodes declared at cluster-creation time. Fall back to the same deterministic
++    // formula used in add().
++    int port = (n - 1 < jmxPorts.length) ? jmxPorts[n - 1] : (7000 + n * 100);
+     if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+-      return new InetSocketAddress(ipOfNode(n), jmxPorts[n - 1]);
++      return new InetSocketAddress(ipOfNode(n), port);
+     } else {
+-      return new InetSocketAddress("localhost", jmxPorts[n - 1]);
++      return new InetSocketAddress("localhost", port);
+     }
+   }
+ 
+@@ -733,23 +737,25 @@ public class CCMBridge implements CCMAccess {
+   public void add(int dc, int n) {
+     logger.debug(
+         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
+-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
+     String storageItf = ipOfNode(n) + ":" + storagePort;
+     String binaryItf = ipOfNode(n) + ":" + binaryPort;
+     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
++    // Use a deterministic JMX port formula to avoid TOCTOU races from findAvailablePort()
++    // and to match the fallback in jmxAddressOfNode() for dynamically added nodes (jmxPorts[]
++    // is sized only for nodes declared at cluster-creation time).
++    int jmxPort = 7000 + n * 100;
+     execute(
+         CCM_COMMAND
+-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
++            + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b"
+             + (isDSE ? " --dse" : "")
+             + (isScylla ? " --scylla" : ""),
+         n,
+         dc,
+         ipPrefix,
+         n,
+-        thriftItf,
+         storageItf,
+         binaryItf,
+-        TestUtils.findAvailablePort(),
++        jmxPort,
+         remoteLogItf);
+   }
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+index a925ecbb86..2670c2022d 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+@@ -119,7 +119,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
+     Cluster cluster = register(createClusterBuilder().build());
+     Session session = cluster.connect();
+     session.execute(
+-        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++        "create keyspace ControlConnectionTest_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     session.execute("create type ControlConnectionTest_ks.foo (i int)");
+     cluster.close();
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+index 26e88c5d87..f3180ab1a3 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+@@ -63,7 +63,7 @@ public class MetadataTest extends CCMTestsSupport {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     Metadata metadata = cluster.getMetadata();
+ 
+     // Capture all Token data.
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+index 25bb3267cf..9d4bdd3da1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+@@ -482,7 +482,7 @@ public class PreparedStatementInvalidationTest extends CCMTestsSupport {
+             .init();
+     Session session = cluster.connect();
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': '1' }");
++        "CREATE KEYSPACE IF NOT EXISTS cql4_loopholes_test WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1' }");
+     session.execute("USE cql4_loopholes_test");
+     return session;
+   }
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+index ea75f84544..ea70e9081a 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
+-@CCMConfig(dirtiesContext = true)
++@CCMConfig(
++    dirtiesContext = true,
++    jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"})
+ public class SessionStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+index b1867a0562..ac36feb518 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+@@ -95,7 +95,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
+     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
+     session()
+         .execute(
+-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
++            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
+     session()
+         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java b/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
+index 28e42df83b..65922dfde0 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/StatementPagesTest.java
+@@ -8,7 +8,7 @@ public class StatementPagesTest extends CCMTestsSupport {
+   @Override
+   public void onTestContextInitialized() {
+     execute(
+-        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}");
+     execute("CREATE TABLE IF NOT EXISTS ks.t (pk int, ck int, v int, PRIMARY KEY(pk, ck))");
+ 
+     for (int i = 0; i < 50; i++) {
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+index 5dea37b8e2..157e59e4b1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+@@ -86,7 +86,7 @@ public abstract class TestUtils {
+   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
+ 
+   public static final String CREATE_KEYSPACE_SIMPLE_FORMAT =
+-      "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }";
++      "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : %d }";
+   public static final String CREATE_KEYSPACE_GENERIC_FORMAT =
+       "CREATE KEYSPACE %s WITH replication = { 'class' : '%s', %s }";
+ 
+ diff --git a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+ index c585ed145d..0039be8579 100644
+ --- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+ +++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+ @@ -24,9 +24,13 @@ package com.datastax.driver.core;
+  import static com.datastax.driver.core.Assertions.assertThat;
+  
+  import com.datastax.driver.core.utils.Bytes;
+ +import com.google.common.base.Throwables;
+  import java.nio.ByteBuffer;
+  import java.util.List;
+ +import java.util.Objects;
+  import java.util.Set;
+ +import org.slf4j.Logger;
+ +import org.slf4j.LoggerFactory;
+  import org.testng.annotations.Test;
+  
+  @CCMConfig(
+ @@ -36,6 +40,36 @@ import org.testng.annotations.Test;
+      clusterProvider = "createClusterBuilderNoDebouncing")
+  public class SingleTokenIntegrationTest extends CCMTestsSupport {
+  
+ +  private static final Logger LOGGER = LoggerFactory.getLogger(SingleTokenIntegrationTest.class);
+ +
+ +  /**
+ +   * Override to create the keyspace with tablets disabled when running against Scylla. This test
+ +   * exercises token-range and token-map based replica lookup (getReplicasList with table == null).
+ +   * With tablets enabled (the default on modern Scylla), replica placement is controlled by the
+ +   * tablet map and getReplicasList returns an empty list when the table is unknown, breaking the
+ +   * test assertions. Cassandra does not support the tablets property.
+ +   */
+ +  @Override
+ +  protected void initTestKeyspace() {
+ +    try {
+ +      keyspace = TestUtils.generateIdentifier("ks_");
+ +      LOGGER.debug("Using keyspace " + keyspace);
+ +      boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
+ +      session()
+ +          .execute(
+ +              String.format(
+ +                  "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+ +                      + " 'datacenter1': 1}"
+ +                      + (isScylla ? " AND tablets = {'enabled': false}" : ""),
+ +                  keyspace));
+ +      useKeyspace(keyspace);
+ +    } catch (Exception e) {
+ +      errorOut();
+ +      LOGGER.error("Could not create test keyspace", e);
+ +      Throwables.propagate(e);
+ +    }
+ +  }
+ +
+    /** JAVA-684: Empty TokenRange returned in a one token cluster */
+    @Test(groups = "short")
+    public void should_return_single_non_empty_range_when_cluster_has_one_single_token() {
+ diff --git a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+ index 61412768bc..1516cf9bbc 100644
+ --- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+ +++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+ @@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
+  import java.util.Collections;
+  import java.util.HashSet;
+  import java.util.List;
+ +import java.util.Objects;
+  import java.util.Set;
+  import org.testng.annotations.Test;
+  
+ @@ -75,12 +76,19 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
+    public void onTestContextInitialized() {
+      ks1 = TestUtils.generateIdentifier("ks_");
+      ks2 = TestUtils.generateIdentifier("ks_");
+ +    // Disable tablets on ks1 when running against Scylla. With tablets enabled (the default on
+ +    // modern Scylla), replica placement is controlled by the tablet map rather than the token map,
+ +    // so getReplicasList(ks, null, null, key) returns an empty list and the assertions fail.
+ +    // Cassandra does not support the tablets property, so the clause is omitted there.
+ +    boolean isScylla = Objects.nonNull(ccm().getScyllaVersion());
+      execute(
+          String.format(
+ -            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+ +            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy',"
+ +                + " 'datacenter1': 1}"
+ +                + (isScylla ? " AND tablets = {'enabled': false}" : ""),
+              ks1),
+          String.format(
+ -            "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
+ +            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 2}",
+              ks2),
+          String.format("USE %s", ks1),
+          "CREATE TABLE foo(i int primary key)",
+ diff --git a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+index f37d2dcce5..1e44f859bc 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+@@ -100,7 +100,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type");
+     session()
+         .execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<tuple<ascii, int, boolean>>)");
+@@ -169,7 +169,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_type_varying_lengths "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_type_varying_lengths");
+ 
+     // programmatically create the table with tuples of said sizes
+@@ -226,7 +226,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_subtypes");
+ 
+     // programmatically create the table with a tuple of all datatypes
+@@ -294,7 +294,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_tuple_non_primitive_subtypes "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_tuple_non_primitive_subtypes");
+ 
+     ArrayList<String> values = new ArrayList<String>();
+@@ -471,7 +471,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE test_nested_tuples "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE test_nested_tuples");
+ 
+     // create a table with multiple sizes of nested tuples
+@@ -519,7 +519,7 @@ public class TupleTest extends CCMTestsSupport {
+     session()
+         .execute(
+             "CREATE KEYSPACE testTuplesWithNulls "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+     session().execute("USE testTuplesWithNulls");
+ 
+     // create UDT
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+index eb9faa0392..2986987915 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+@@ -34,7 +34,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+   private static final String EXPECTED_SCHEMA =
+       String.format(
+-          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;\n"
++          "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '1' } AND DURABLE_WRITES = true;\n"
+               + "\n"
+               + "CREATE TYPE %s.g (\n"
+               + "    f1 int\n"
+@@ -89,7 +89,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
+ 
+          Topological sort order should be : gh,FE,D,CB,A
+          */
+-        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
++        "CREATE KEYSPACE unresolved_user_type_test WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'}",
+         String.format("CREATE TYPE %s.h (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.g (f1 int)", KEYSPACE),
+         String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", KEYSPACE),
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+index 42a352c703..7c48652e7c 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+@@ -150,7 +150,7 @@ public class UserTypesTest extends CCMTestsSupport {
+             "CREATE KEYSPACE "
+                 + otherKeyspaceName
+                 + " "
+-                + "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
++                + "WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1': '1'}");
+ 
+     KeyspaceMetadata otherKeyspace = cluster().getMetadata().getKeyspace(otherKeyspaceName);
+     assertThat(otherKeyspace.getUserType(quote("\"User Address\""))).isNull();
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+index eeb57e91b2..acc44b2c51 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+@@ -22,7 +22,6 @@
+ package com.datastax.driver.core.policies;
+ 
+ import static com.datastax.driver.core.Assertions.assertThat;
+-import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
+ import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
+ import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.NEUTRAL;
+ import static com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering.RANDOM;
+@@ -980,7 +979,10 @@ public class TokenAwarePolicyTest {
+       Session session = cluster.connect();
+ 
+       String ks = TestUtils.generateIdentifier("ks_");
+-      session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, 1));
++      session.execute(
++          String.format(
++              "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } AND tablets = {'enabled': false}",
++              ks));
+       session.execute("USE " + ks);
+       session.execute("CREATE TABLE composite (k1 int, k2 int, i int, PRIMARY KEY ((k1, k2)))");
+ 

--- a/versions/scylla/3.11.5.15/ignore.yaml
+++ b/versions/scylla/3.11.5.15/ignore.yaml
@@ -1,0 +1,20 @@
+tests:
+  # test count on tracing which its content is different in scylla, should be skipped on scylla
+  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+
+  # disable because now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest
+
+  # using 2 node cluster, and stopping one, isn't supported by scylla since raft
+  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest
+
+  # scylla-ccm no longer supports --sni-proxy option
+  - ScyllaSniProxyTest
+
+  # node stop/start sequence causes Scylla to fail to open its binary port within the 5-minute
+  # CCM timeout, likely due to timing differences vs Cassandra in this driver version
+  - NodeRefreshDebouncerTest #should_call_onAdd_with_bootstrap_stop_start

--- a/versions/scylla/3.11.5.15/patch
+++ b/versions/scylla/3.11.5.15/patch
@@ -1,0 +1,83 @@
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+index 344678c814..74a126cb20 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+@@ -207,11 +207,11 @@ public class CCMBridge implements CCMAccess {
+       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
+     } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+       installArgs.add(" --scylla ");
+-      if (isVersionNumber(inputScyllaVersion)) {
+-        installArgs.add("-v release:" + inputScyllaVersion);
+-      } else {
+-        installArgs.add("-v " + inputScyllaVersion);
+-      }
++      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
++      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
++      // proven difficult.
++      installArgs.add("-v " + inputScyllaVersion);
++
+       // Detect Scylla Enterprise - it should start with
+       // a 4-digit year.
+       if (inputScyllaVersion.matches("\\d{4}\\..*")) {
+@@ -480,10 +480,14 @@ public class CCMBridge implements CCMAccess {
+ 
+   @Override
+   public InetSocketAddress jmxAddressOfNode(int n) {
++    // For dynamically added nodes (via add()), jmxPorts[] may not have an entry since it is
++    // sized only for nodes declared at cluster-creation time. Fall back to the same deterministic
++    // formula used in add().
++    int port = (n - 1 < jmxPorts.length) ? jmxPorts[n - 1] : (7000 + n * 100);
+     if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+-      return new InetSocketAddress(ipOfNode(n), jmxPorts[n - 1]);
++      return new InetSocketAddress(ipOfNode(n), port);
+     } else {
+-      return new InetSocketAddress("localhost", jmxPorts[n - 1]);
++      return new InetSocketAddress("localhost", port);
+     }
+   }
+ 
+@@ -733,23 +737,25 @@ public class CCMBridge implements CCMAccess {
+   public void add(int dc, int n) {
+     logger.debug(
+         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
+-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
+     String storageItf = ipOfNode(n) + ":" + storagePort;
+     String binaryItf = ipOfNode(n) + ":" + binaryPort;
+     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
++    // Use a deterministic JMX port formula to avoid TOCTOU races from findAvailablePort()
++    // and to match the fallback in jmxAddressOfNode() for dynamically added nodes (jmxPorts[]
++    // is sized only for nodes declared at cluster-creation time).
++    int jmxPort = 7000 + n * 100;
+     execute(
+         CCM_COMMAND
+-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
++            + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b"
+             + (isDSE ? " --dse" : "")
+             + (isScylla ? " --scylla" : ""),
+         n,
+         dc,
+         ipPrefix,
+         n,
+-        thriftItf,
+         storageItf,
+         binaryItf,
+-        TestUtils.findAvailablePort(),
++        jmxPort,
+         remoteLogItf);
+   }
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+index ea75f84544..ea70e9081a 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
+-@CCMConfig(dirtiesContext = true)
++@CCMConfig(
++    dirtiesContext = true,
++    jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"})
+ public class SessionStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -48,6 +48,97 @@ index d70c6d3fac..c9839c3b93 100644
    @Test
    public void should_successfully_send_peers_v2_node_refresh_query()
        throws InterruptedException, ExecutionException {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+index 1d02c42b52..8c1f8212b0 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+@@ -375,7 +375,7 @@ public class SimpleStatementCcmIT {
+     SESSION_RULE
+         .session()
+         .execute(
+-            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
+ 
+     SESSION_RULE
+         .session()
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+index 5351557bc4..d025c0bd29 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+@@ -66,7 +66,8 @@ public class LWTLoadBalancingIT {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace.asCql(false)
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}"
++            + " AND tablets = {'enabled': false}");
+     session.execute("USE " + keyspace.asCql(false));
+     session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+   }
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+index d9156b860c..e69856d8f1 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+@@ -102,16 +102,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -124,7 +123,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -139,11 +138,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index 057461a1bd..393b968cdc 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
 index ca421d1ad4..a665f75b33 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -191,6 +282,32 @@ index 1cff5d998a..5fe8d51bf9 100644
        MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
        MultimapHostResolverProvider.addResolverEntry(
            "test.cluster.fake", ccmBridge.getNodeIpAddress(1));
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87a..376834519a 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363f..06810507ed 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
 index ef87040f2a..29479f27ee 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
@@ -241,6 +358,19 @@ index aa04c058a4..5d0a67f8aa 100644
  public class MicroProfileMetricsIT extends MetricsITBase {
  
    @ClassRule
+diff --git a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+index 1da97d7d61..d7bb70ebf2 100644
+--- a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
++++ b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+@@ -69,7 +69,7 @@ public class MailboxServiceImpl implements MailboxService {
+   protected void createSchema() {
+     session.execute("DROP KEYSPACE IF EXISTS test_osgi");
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}");
+     session.execute(
+         "CREATE TABLE "
+             + keyspace
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 index 2e137b0854..6c311cd4f2 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -434,3 +564,16 @@ index 79cc0f7e60..6240cc58ba 100644
      public CustomCcmRule build() {
        return new CustomCcmRule(bridgeBuilder.build());
      }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffdc..6e13cc5cf5 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -48,6 +48,96 @@ index d70c6d3fac..c9839c3b93 100644
    @Test
    public void should_successfully_send_peers_v2_node_refresh_query()
        throws InterruptedException, ExecutionException {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+index 1d02c42b52..8c1f8212b0 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+@@ -375,7 +375,7 @@ public class SimpleStatementCcmIT {
+     SESSION_RULE
+         .session()
+         .execute(
+-            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
+ 
+     SESSION_RULE
+         .session()
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+index 5351557bc4..d025c0bd29 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+@@ -66,7 +66,7 @@ public class LWTLoadBalancingIT {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace.asCql(false)
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}");
+     session.execute("USE " + keyspace.asCql(false));
+     session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+   }
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+index d9156b860c..e69856d8f1 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+@@ -102,16 +102,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -124,7 +123,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -139,11 +138,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index 057461a1bd..393b968cdc 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
 index ca421d1ad4..a665f75b33 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/ZeroTokenNodesIT.java
@@ -191,6 +281,32 @@ index 1cff5d998a..5fe8d51bf9 100644
        MultimapHostResolverProvider.removeResolverEntries("test.cluster.fake");
        MultimapHostResolverProvider.addResolverEntry(
            "test.cluster.fake", ccmBridge.getNodeIpAddress(1));
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87a..376834519a 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363f..06810507ed 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
 index ef87040f2a..29479f27ee 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
@@ -241,6 +357,19 @@ index aa04c058a4..5d0a67f8aa 100644
  public class MicroProfileMetricsIT extends MetricsITBase {
  
    @ClassRule
+diff --git a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+index 1da97d7d61..d7bb70ebf2 100644
+--- a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
++++ b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+@@ -69,7 +69,7 @@ public class MailboxServiceImpl implements MailboxService {
+   protected void createSchema() {
+     session.execute("DROP KEYSPACE IF EXISTS test_osgi");
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}");
+     session.execute(
+         "CREATE TABLE "
+             + keyspace
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 index 2e137b0854..6c311cd4f2 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -434,3 +563,16 @@ index 79cc0f7e60..6240cc58ba 100644
      public CustomCcmRule build() {
        return new CustomCcmRule(bridgeBuilder.build());
      }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffdc..6e13cc5cf5 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();

--- a/versions/scylla/4.19.0.8/patch
+++ b/versions/scylla/4.19.0.8/patch
@@ -1,5 +1,5 @@
 diff --git a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
-index d126c3524c..95dd5f7e2b 100644
+index d126c3524c..4aa8a65fb6 100644
 --- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
 +++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
 @@ -63,6 +63,16 @@ public final class ClientRoutesConfig {
@@ -92,10 +92,10 @@ index d126c3524c..95dd5f7e2b 100644
  
      /**
       * Adds an endpoint to the configuration.
-@@ -208,15 +238,34 @@ public final class ClientRoutesConfig {
+@@ -208,6 +238,25 @@ public final class ClientRoutesConfig {
        return this;
      }
-
+ 
 +    /**
 +     * Sets the native transport port of the cluster nodes. This is used as the fallback port for
 +     * {@code broadcastRpcAddress} when system tables do not include port information. Only needed
@@ -118,8 +118,7 @@ index d126c3524c..95dd5f7e2b 100644
      /**
       * Builds the {@link ClientRoutesConfig} with the configured endpoints and table name.
       *
-      * @return the new configuration instance.
-      * @throws IllegalArgumentException if no endpoints have been added.
+@@ -216,7 +265,7 @@ public final class ClientRoutesConfig {
       */
      @NonNull
      public ClientRoutesConfig build() {
@@ -226,7 +225,7 @@ index 1d6b74cb60..a1f836ab15 100644
        // If reconnectOnFailure was true and we've never connected before, complete the future now to
        // signal that the initialization is complete.
 diff --git a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
-index 041508b8f2..be47719c7b 100644
+index 041508b8f2..950221627a 100644
 --- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
 +++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
 @@ -130,6 +130,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
@@ -237,7 +236,7 @@ index 041508b8f2..be47719c7b 100644
      this.configuredConnectionIds =
          Collections.unmodifiableList(
              config.getEndpoints().stream()
-@@ -438,36 +439,14 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
+@@ -438,36 +439,15 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    }
  
    /**
@@ -248,11 +247,12 @@ index 041508b8f2..be47719c7b 100644
 -   *
 -   * <p>All nodes in a Scylla/Cassandra cluster use the same native transport port, so any route's
 -   * port is correct. We use the minimum host_id for deterministic selection.
-+   * No-op: the port is set in the constructor from {@link ClientRoutesConfig#getNativeTransportPort()}. The default implementation would save the control channel's endpoint port, which is the
-+   * NLB proxy port — not the real native transport port. Using the proxy port would cause {@link
-+   * #getBroadcastRpcAddress} to build incorrect {@code broadcastRpcAddress} values, preventing
-+   * {@code Metadata.findNode()} from matching TOPOLOGY_CHANGE events (which carry the real native
-+   * transport port).
++   * No-op: the port is set in the constructor from {@link
++   * ClientRoutesConfig#getNativeTransportPort()}. The default implementation would save the control
++   * channel's endpoint port, which is the NLB proxy port — not the real native transport port.
++   * Using the proxy port would cause {@link #getBroadcastRpcAddress} to build incorrect {@code
++   * broadcastRpcAddress} values, preventing {@code Metadata.findNode()} from matching
++   * TOPOLOGY_CHANGE events (which carry the real native transport port).
     */
    @Override
 -  protected void savePort(DriverChannel channel) {
@@ -378,6 +378,59 @@ index d70c6d3fac..c9839c3b93 100644
    @Test
    public void should_successfully_send_peers_v2_node_refresh_query()
        throws InterruptedException, ExecutionException {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+index 504f01e3ce..015da02ebd 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+@@ -71,12 +71,15 @@ public class ProtocolVersionMixedClusterIT {
+       assertThat(context.getControlConnection().channel().protocolVersion())
+           .isEqualTo(DefaultProtocolVersion.V4);
+ 
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+ 
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
+@@ -100,11 +103,14 @@ public class ProtocolVersionMixedClusterIT {
+ 
+       InternalDriverContext context = (InternalDriverContext) session.getContext();
+       assertThat(context.getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
+@@ -151,11 +157,14 @@ public class ProtocolVersionMixedClusterIT {
+                     .build()) {
+       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
+ 
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
 index 9a23f36854..872f1221d7 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
@@ -406,10 +459,10 @@ index 9a23f36854..872f1221d7 100644
          nlb.addNode(1);
  
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
-index 6d68a9336a..0097b6a2af 100644
+index 6d68a9336a..15f6061221 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
-@@ -112,20 +112,23 @@ public class NlbSimulator implements Closeable {
+@@ -112,19 +112,25 @@ public class NlbSimulator implements Closeable {
      String nodeIp = ccmBridge.getNodeIpAddress(nodeId);
      InetSocketAddress nodeAddr = new InetSocketAddress(nodeIp, 9042);
  
@@ -420,29 +473,26 @@ index 6d68a9336a..0097b6a2af 100644
 -    // Update state and rebuild discovery proxy; if rebuild fails, close the new proxy
      activeNodes.add(nodeId);
      nodeProxies.put(nodeId, proxy);
--    try {
--      rebuildDiscoveryProxy();
--    } catch (IOException e) {
--      activeNodes.remove(Integer.valueOf(nodeId));
--      nodeProxies.remove(nodeId);
--      proxy.close();
--      throw e;
 +
-+    try {
+     try {
+-      rebuildDiscoveryProxy();
 +      if (discoveryProxy == null) {
 +        discoveryProxy = buildDiscoveryProxy(nodeAddr);
 +      } else {
 +        discoveryProxy.addTarget(nodeAddr);
 +      }
-+    } catch (IOException e) {
-+      activeNodes.remove(Integer.valueOf(nodeId));
-+      nodeProxies.remove(nodeId);
-+      try { proxy.close(); } catch (Exception ignored) {}
-+      throw e;
+     } catch (IOException e) {
+       activeNodes.remove(Integer.valueOf(nodeId));
+       nodeProxies.remove(nodeId);
+-      proxy.close();
++      try {
++        proxy.close();
++      } catch (Exception ignored) {
++      }
+       throw e;
      }
  
-     LOG.info("NLB: added node{} ({}:{}) -> proxy port {}", nodeId, nodeIp, 9042, nodePort);
-@@ -139,37 +135,25 @@ public class NlbSimulator implements Closeable {
+@@ -139,37 +145,25 @@ public class NlbSimulator implements Closeable {
      }
      activeNodes.remove(Integer.valueOf(nodeId));
  
@@ -535,8 +585,111 @@ index 964abf05bf..0252ab6678 100644
    private void acceptLoop() {
      while (!closed.get()) {
        try {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+index 1d02c42b52..8c1f8212b0 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+@@ -375,7 +375,7 @@ public class SimpleStatementCcmIT {
+     SESSION_RULE
+         .session()
+         .execute(
+-            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
+ 
+     SESSION_RULE
+         .session()
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+index 0586b3236b..6aa8dfb81e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+@@ -72,7 +72,7 @@ public class LWTLoadBalancingIT {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace.asCql(false)
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}");
+     session.execute("USE " + keyspace.asCql(false));
+     session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+   }
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+index a03320f261..79cc53e569 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+@@ -99,16 +99,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -121,7 +120,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -136,11 +135,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index c97a2279ef..21f678fc26 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+index aeda4a02c7..782aa2dfdb 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+@@ -234,7 +234,7 @@ public class AdvancedShardAwarenessIT {
+         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
+       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
+       Awaitility.await()
+-          .atMost(20, TimeUnit.SECONDS)
++          .atMost(60, TimeUnit.SECONDS)
+           .pollInterval(500, TimeUnit.MILLISECONDS)
+           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
+       int tolerance = 2; // Sometimes socket ends up already in use
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
-index 0498462ce1..c26b82334a 100644
+index 0498462ce1..d99e0d3f68 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 @@ -274,8 +274,10 @@ public class MockResolverIT {
@@ -552,6 +705,45 @@ index 0498462ce1..c26b82334a 100644
          break;
        }
        LOG.warn(
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87a..376834519a 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363f..06810507ed 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
+diff --git a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+index 1da97d7d61..d7bb70ebf2 100644
+--- a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
++++ b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+@@ -69,7 +69,7 @@ public class MailboxServiceImpl implements MailboxService {
+   protected void createSchema() {
+     session.execute("DROP KEYSPACE IF EXISTS test_osgi");
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}");
+     session.execute(
+         "CREATE TABLE "
+             + keyspace
 diff --git a/pom.xml b/pom.xml
 index 96fb2401c4..2e491fbafa 100644
 --- a/pom.xml
@@ -760,7 +952,7 @@ index e7b2b4e4a0..8fbbed8d95 100644
    }
  
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
-index 5ea1bf7ed3..d2491ab8df 100644
+index 5ea1bf7ed3..3f7f5be283 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 @@ -17,6 +17,7 @@
@@ -802,70 +994,16 @@ index 5ea1bf7ed3..d2491ab8df 100644
      public CustomCcmRule build() {
        return new CustomCcmRule(bridgeBuilder.build());
      }
-diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-index 504f01e3ce..015da02ebd 100644
---- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-@@ -71,12 +71,15 @@ public class ProtocolVersionMixedClusterIT {
-       assertThat(context.getControlConnection().channel().protocolVersion())
-           .isEqualTo(DefaultProtocolVersion.V4);
- 
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
- 
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-@@ -100,11 +103,14 @@ public class ProtocolVersionMixedClusterIT {
- 
-       InternalDriverContext context = (InternalDriverContext) session.getContext();
-       assertThat(context.getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-@@ -151,11 +157,14 @@ public class ProtocolVersionMixedClusterIT {
-                     .build()) {
-       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
- 
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-
-diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-index aeda4a02c7..782aa2dfdb 100644
---- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-@@ -234,7 +234,7 @@ public class AdvancedShardAwarenessIT {
-         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
-       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
-       Awaitility.await()
--          .atMost(20, TimeUnit.SECONDS)
-+          .atMost(60, TimeUnit.SECONDS)
-           .pollInterval(500, TimeUnit.MILLISECONDS)
-           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
-       int tolerance = 2; // Sometimes socket ends up already in use
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffdc..6e13cc5cf5 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();

--- a/versions/scylla/4.19.0.8/patch
+++ b/versions/scylla/4.19.0.8/patch
@@ -1,5 +1,5 @@
 diff --git a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
-index d126c3524c..95dd5f7e2b 100644
+index d126c3524c..4aa8a65fb6 100644
 --- a/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
 +++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/ClientRoutesConfig.java
 @@ -63,6 +63,16 @@ public final class ClientRoutesConfig {
@@ -92,10 +92,10 @@ index d126c3524c..95dd5f7e2b 100644
  
      /**
       * Adds an endpoint to the configuration.
-@@ -208,15 +238,34 @@ public final class ClientRoutesConfig {
+@@ -208,6 +238,25 @@ public final class ClientRoutesConfig {
        return this;
      }
-
+ 
 +    /**
 +     * Sets the native transport port of the cluster nodes. This is used as the fallback port for
 +     * {@code broadcastRpcAddress} when system tables do not include port information. Only needed
@@ -118,8 +118,7 @@ index d126c3524c..95dd5f7e2b 100644
      /**
       * Builds the {@link ClientRoutesConfig} with the configured endpoints and table name.
       *
-      * @return the new configuration instance.
-      * @throws IllegalArgumentException if no endpoints have been added.
+@@ -216,7 +265,7 @@ public final class ClientRoutesConfig {
       */
      @NonNull
      public ClientRoutesConfig build() {
@@ -226,7 +225,7 @@ index 1d6b74cb60..a1f836ab15 100644
        // If reconnectOnFailure was true and we've never connected before, complete the future now to
        // signal that the initialization is complete.
 diff --git a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
-index 041508b8f2..be47719c7b 100644
+index 041508b8f2..950221627a 100644
 --- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
 +++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/ClientRoutesTopologyMonitor.java
 @@ -130,6 +130,7 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
@@ -237,7 +236,7 @@ index 041508b8f2..be47719c7b 100644
      this.configuredConnectionIds =
          Collections.unmodifiableList(
              config.getEndpoints().stream()
-@@ -438,36 +439,14 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
+@@ -438,36 +439,15 @@ public class ClientRoutesTopologyMonitor extends DefaultTopologyMonitor {
    }
  
    /**
@@ -248,11 +247,12 @@ index 041508b8f2..be47719c7b 100644
 -   *
 -   * <p>All nodes in a Scylla/Cassandra cluster use the same native transport port, so any route's
 -   * port is correct. We use the minimum host_id for deterministic selection.
-+   * No-op: the port is set in the constructor from {@link ClientRoutesConfig#getNativeTransportPort()}. The default implementation would save the control channel's endpoint port, which is the
-+   * NLB proxy port — not the real native transport port. Using the proxy port would cause {@link
-+   * #getBroadcastRpcAddress} to build incorrect {@code broadcastRpcAddress} values, preventing
-+   * {@code Metadata.findNode()} from matching TOPOLOGY_CHANGE events (which carry the real native
-+   * transport port).
++   * No-op: the port is set in the constructor from {@link
++   * ClientRoutesConfig#getNativeTransportPort()}. The default implementation would save the control
++   * channel's endpoint port, which is the NLB proxy port — not the real native transport port.
++   * Using the proxy port would cause {@link #getBroadcastRpcAddress} to build incorrect {@code
++   * broadcastRpcAddress} values, preventing {@code Metadata.findNode()} from matching
++   * TOPOLOGY_CHANGE events (which carry the real native transport port).
     */
    @Override
 -  protected void savePort(DriverChannel channel) {
@@ -378,6 +378,59 @@ index d70c6d3fac..c9839c3b93 100644
    @Test
    public void should_successfully_send_peers_v2_node_refresh_query()
        throws InterruptedException, ExecutionException {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+index 504f01e3ce..015da02ebd 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
+@@ -71,12 +71,15 @@ public class ProtocolVersionMixedClusterIT {
+       assertThat(context.getControlConnection().channel().protocolVersion())
+           .isEqualTo(DefaultProtocolVersion.V4);
+ 
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+ 
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
+@@ -100,11 +103,14 @@ public class ProtocolVersionMixedClusterIT {
+ 
+       InternalDriverContext context = (InternalDriverContext) session.getContext();
+       assertThat(context.getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
+@@ -151,11 +157,14 @@ public class ProtocolVersionMixedClusterIT {
+                     .build()) {
+       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
+ 
+-      assertThat(queries(simulacron)).hasSize(4);
++      assertThat(queries(simulacron)).hasSize(5);
+       assertThat(protocolQueries(contactPoint, 4))
+           .containsExactly(
+               // Initial connection with protocol v4
+               "SELECT cluster_name FROM system.local WHERE key='local'",
++              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
++              // connection channel endpoint
++              "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.local WHERE key='local'",
+               "SELECT * FROM system.peers_v2",
+               "SELECT * FROM system.peers");
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
 index 9a23f36854..872f1221d7 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
@@ -406,10 +459,10 @@ index 9a23f36854..872f1221d7 100644
          nlb.addNode(1);
  
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
-index 6d68a9336a..0097b6a2af 100644
+index 6d68a9336a..15f6061221 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/NlbSimulator.java
-@@ -112,20 +112,23 @@ public class NlbSimulator implements Closeable {
+@@ -112,19 +112,25 @@ public class NlbSimulator implements Closeable {
      String nodeIp = ccmBridge.getNodeIpAddress(nodeId);
      InetSocketAddress nodeAddr = new InetSocketAddress(nodeIp, 9042);
  
@@ -420,29 +473,26 @@ index 6d68a9336a..0097b6a2af 100644
 -    // Update state and rebuild discovery proxy; if rebuild fails, close the new proxy
      activeNodes.add(nodeId);
      nodeProxies.put(nodeId, proxy);
--    try {
--      rebuildDiscoveryProxy();
--    } catch (IOException e) {
--      activeNodes.remove(Integer.valueOf(nodeId));
--      nodeProxies.remove(nodeId);
--      proxy.close();
--      throw e;
 +
-+    try {
+     try {
+-      rebuildDiscoveryProxy();
 +      if (discoveryProxy == null) {
 +        discoveryProxy = buildDiscoveryProxy(nodeAddr);
 +      } else {
 +        discoveryProxy.addTarget(nodeAddr);
 +      }
-+    } catch (IOException e) {
-+      activeNodes.remove(Integer.valueOf(nodeId));
-+      nodeProxies.remove(nodeId);
-+      try { proxy.close(); } catch (Exception ignored) {}
-+      throw e;
+     } catch (IOException e) {
+       activeNodes.remove(Integer.valueOf(nodeId));
+       nodeProxies.remove(nodeId);
+-      proxy.close();
++      try {
++        proxy.close();
++      } catch (Exception ignored) {
++      }
+       throw e;
      }
  
-     LOG.info("NLB: added node{} ({}:{}) -> proxy port {}", nodeId, nodeIp, 9042, nodePort);
-@@ -139,37 +135,25 @@ public class NlbSimulator implements Closeable {
+@@ -139,37 +145,25 @@ public class NlbSimulator implements Closeable {
      }
      activeNodes.remove(Integer.valueOf(nodeId));
  
@@ -535,8 +585,112 @@ index 964abf05bf..0252ab6678 100644
    private void acceptLoop() {
      while (!closed.get()) {
        try {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+index 1d02c42b52..8c1f8212b0 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/SimpleStatementCcmIT.java
+@@ -375,7 +375,7 @@ public class SimpleStatementCcmIT {
+     SESSION_RULE
+         .session()
+         .execute(
+-            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
++            "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}");
+ 
+     SESSION_RULE
+         .session()
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+index 0586b3236b..6aa8dfb81e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/LWTLoadBalancingIT.java
+@@ -72,7 +72,8 @@ public class LWTLoadBalancingIT {
+     session.execute(
+         "CREATE KEYSPACE "
+             + keyspace.asCql(false)
+-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}");
++            + " WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}"
++            + " AND tablets = {'enabled': false}");
+     session.execute("USE " + keyspace.asCql(false));
+     session.execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+   }
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+index a03320f261..79cc53e569 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+@@ -99,16 +99,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -121,7 +120,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -136,11 +135,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index c97a2279ef..21f678fc26 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+index aeda4a02c7..782aa2dfdb 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+@@ -234,7 +234,7 @@ public class AdvancedShardAwarenessIT {
+         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
+       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
+       Awaitility.await()
+-          .atMost(20, TimeUnit.SECONDS)
++          .atMost(60, TimeUnit.SECONDS)
+           .pollInterval(500, TimeUnit.MILLISECONDS)
+           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
+       int tolerance = 2; // Sometimes socket ends up already in use
 diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
-index 0498462ce1..c26b82334a 100644
+index 0498462ce1..d99e0d3f68 100644
 --- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 +++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
 @@ -274,8 +274,10 @@ public class MockResolverIT {
@@ -552,6 +706,45 @@ index 0498462ce1..c26b82334a 100644
          break;
        }
        LOG.warn(
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e87a..376834519a 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c0363f..06810507ed 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
+diff --git a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+index 1da97d7d61..d7bb70ebf2 100644
+--- a/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
++++ b/osgi-tests/src/main/java/com/datastax/oss/driver/internal/osgi/service/MailboxServiceImpl.java
+@@ -69,7 +69,7 @@ public class MailboxServiceImpl implements MailboxService {
+   protected void createSchema() {
+     session.execute("DROP KEYSPACE IF EXISTS test_osgi");
+     session.execute(
+-        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++        "CREATE KEYSPACE IF NOT EXISTS test_osgi with replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}");
+     session.execute(
+         "CREATE TABLE "
+             + keyspace
 diff --git a/pom.xml b/pom.xml
 index 96fb2401c4..2e491fbafa 100644
 --- a/pom.xml
@@ -760,7 +953,7 @@ index e7b2b4e4a0..8fbbed8d95 100644
    }
  
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
-index 5ea1bf7ed3..d2491ab8df 100644
+index 5ea1bf7ed3..3f7f5be283 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 +++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
 @@ -17,6 +17,7 @@
@@ -802,70 +995,16 @@ index 5ea1bf7ed3..d2491ab8df 100644
      public CustomCcmRule build() {
        return new CustomCcmRule(bridgeBuilder.build());
      }
-diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-index 504f01e3ce..015da02ebd 100644
---- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionMixedClusterIT.java
-@@ -71,12 +71,15 @@ public class ProtocolVersionMixedClusterIT {
-       assertThat(context.getControlConnection().channel().protocolVersion())
-           .isEqualTo(DefaultProtocolVersion.V4);
- 
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
- 
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-@@ -100,11 +103,14 @@ public class ProtocolVersionMixedClusterIT {
- 
-       InternalDriverContext context = (InternalDriverContext) session.getContext();
-       assertThat(context.getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-@@ -151,11 +157,14 @@ public class ProtocolVersionMixedClusterIT {
-                     .build()) {
-       assertThat(session.getContext().getProtocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
- 
--      assertThat(queries(simulacron)).hasSize(4);
-+      assertThat(queries(simulacron)).hasSize(5);
-       assertThat(protocolQueries(contactPoint, 4))
-           .containsExactly(
-               // Initial connection with protocol v4
-               "SELECT cluster_name FROM system.local WHERE key='local'",
-+              // An extra query done by TopologyMonitor.getChannelEndpoint to resolve control
-+              // connection channel endpoint
-+              "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.local WHERE key='local'",
-               "SELECT * FROM system.peers_v2",
-               "SELECT * FROM system.peers");
-
-diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-index aeda4a02c7..782aa2dfdb 100644
---- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
-@@ -234,7 +234,7 @@ public class AdvancedShardAwarenessIT {
-         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
-       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
-       Awaitility.await()
--          .atMost(20, TimeUnit.SECONDS)
-+          .atMost(60, TimeUnit.SECONDS)
-           .pollInterval(500, TimeUnit.MILLISECONDS)
-           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
-       int tolerance = 2; // Sometimes socket ends up already in use
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffdc..6e13cc5cf5 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 };",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();


### PR DESCRIPTION
## Problem

ScyllaDB PR [scylladb/scylladb#25342](https://github.com/scylladb/scylladb/pull/25342) changed `ks_prop_defs::as_ks_metadata()` so that when tablets are globally enabled (the default on recent ScyllaDB), `initial_tablets = 0` is set for **all** replication strategies. `SimpleStrategy` then validates tablet support and throws:

```
InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication
```

This caused Jenkins build [#1989](https://jenkins.scylladb.com/job/scylla-master/job/driver-tests/job/java-driver-matrix-test/1989/) to regress across all tested 3.x and 4.x driver versions:

| Driver | Errors |
|---|---|
| datastax 4.19.2 | +89 errors |
| datastax 4.19.1 | +97 errors |
| scylla 4.19.0.8 | +84 errors |
| scylla 4.18.1.0 | +105 errors |
| scylla 3.x | affected (not in #1989 matrix, addressed in this PR) |

The majority of failures cascaded from `SessionUtils.createKeyspace()` (called by `SessionRule.before()`), which hardcodes `SimpleStrategy` — causing entire test classes to be skipped when it throws.

## Fix

Replace `SimpleStrategy` with `NetworkTopologyStrategy` in all integration test keyspace creation statements in each version's patch. The DC name follows CCM convention: `dc1` for 4.x driver tests, `datacenter1` for 3.x driver tests. NTS supports tablets and is the correct strategy for single-DC test clusters.

## Changes per patch

Each updated patch is a **single combined diff** (existing Scylla compatibility changes + new NTS migration) applied from the clean tag.

### 4.x patches (datastax/4.19.1, datastax/4.19.2, scylla/4.18.1.0, scylla/4.19.0.8)

DC name: `dc1` (CCM default for 4.x). Key changes:
- `SessionUtils.createKeyspace()` — central fix, resolves majority of cascading failures
- `SchemaChangesIT` — CQL statements updated + assertion updated (`dc1` key instead of `replication_factor`, `hasSize(2)` removed since NTS maps contain more entries)
- `TokenITBase`, `SimpleStatementCcmIT` — CQL statements
- `LWTLoadBalancingIT`, `MailboxServiceImpl` — CQL statements (ScyllaDB driver versions only)
- `DefaultKeyspaceIT`, `QueryKeyspaceAndTableIT` — mapper test CQL statements

### scylla/3.11.5.14 (new patch)

The matrix framework falls back to the most recent existing patch version when a specific version has no patch. Since `3.11.5.14` is the current latest 3.x release, it is more appropriate to aggregate all fixes into it rather than updating older patch files.

This patch is created from scratch (the version had no prior patch) and includes everything needed to pass Jenkins tests on modern Scylla (`2026.2.0~dev`):

**SimpleStrategy → NTS migration** (DC name: `datacenter1`, CCM default for 3.x):
- `TestUtils.java` — `CREATE_KEYSPACE_SIMPLE_FORMAT` constant (fixes all callers: `CCMTestsSupport`, `AbstractPoliciesTest`, etc.)
- `AsyncQueryTest`, `ControlConnectionTest`, `MetadataTest`, `PreparedStatementInvalidationTest`, `ShardAwarenessTest`, `StatementPagesTest`, `TokenIntegrationTest`, `TupleTest`, `UnresolvedUserTypeTest`, `UserTypesTest` — inline CQL statements

**CCMBridge compatibility fixes** (modern Scylla CCM):
- Remove `release:` prefix logic — `VersionNumber.parse("2026.2.0~dev")` succeeds, causing `release:2026.2.0~dev` to be passed to CCM which fails. Now passes the version string bare.
- Remove `-t` (thrift) flag from `ccm add` — CCM dropped thrift support.
- Use deterministic `jmxPort = 7000 + n * 100` in `add()` instead of `findAvailablePort()` to avoid TOCTOU races and match the fallback in `jmxAddressOfNode()`.

**`SessionStressTest`** — add `jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"}` to `@CCMConfig` to prevent connection pool exhaustion on Scylla with high shard counts.

**`TokenAwarePolicyTest` — disable tablets for composite-key routing test** — after the NTS migration, Scylla creates keyspaces with tablets enabled by default. The `3.x` driver's tablet-aware `getReplicas()` then routes via the tablet map rather than the token map, breaking the test's hardcoded expectation that token `4881097376275569167` for composite key `(1,2)` maps to node 1. Fix: create the keyspace with `AND tablets = {'enabled': false}` to force deterministic token-map routing. This fix is also added to the driver in [scylladb/java-driver#876](https://github.com/scylladb/java-driver/pull/876).

### scylla/3.11.4.0 (updated patch)

SimpleStrategy → NTS migration only (DC name: `datacenter1`), same set of files as `3.11.5.14` minus the CCMBridge/SessionStressTest/TokenAwarePolicyTest changes (those are not needed for `3.11.4.0` which predates tablet support in the driver).

## Not covered

**`scylla/3.11.5.12` and `scylla/3.11.5.13`** — these versions also have `SimpleStrategy` in `TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT` and no existing patch to override it. They will fail the same way on modern Scylla. Since the framework selects the most recent patch version and `3.11.5.14` is now covered, these are lower priority but should be addressed if they are included in the test matrix.

## Verified

Each patch was applied to a clean worktree at the corresponding tag and compiled successfully with `mvn compile`. The two remaining failures from the previous Jenkins run (`SessionStressTest`, `TokenAwarePolicyTest`) were reproduced locally against Scylla `2026.1.0` and confirmed passing with the fixes applied.

Full matrix validation (scylla 3.x × 2 versions, scylla 4.x × 2 versions, datastax 4.x × 2 versions) is running in [Jenkins build #19](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-test/19/).

## Corresponding driver fixes

- **4.x**: [scylladb/java-driver#875](https://github.com/scylladb/java-driver/pull/875) (branch `scylla-4.x`)
- **3.x**: [scylladb/java-driver#876](https://github.com/scylladb/java-driver/pull/876) (branch `scylla-3.x`) — NTS migration + TokenAwarePolicyTest tablet fix