### PR TITLE
feat: add datastax 4.19.3 patch migrated from 4.19.2

### DIFF
--- a/versions/datastax/4.19.3/ignore.yaml
+++ b/versions/datastax/4.19.3/ignore.yaml
@@ -1,0 +1,48 @@
+tests:
+    # Unsupported CUSTOM INDEX class org.apache.cassandra.index.sasi.SASIIndex. Note that currently, Scylla does not support SASI or any other CUSTOM INDEX class.
+    - InsertIT
+    - SelectCustomWhereClauseIT
+    - UpdateCustomIfClauseIT
+    - SchemaValidationIT
+    - UpdateReactiveIT
+
+    # Unknown property 'additional_write_policy'
+    - DescribeIT
+
+    # RandomPartitioner isn't supported by scylla anymore
+    - RandomTokenIT
+
+    # ssl issue - init query OPTIONS: error writing )
+    - DefaultSslEngineFactoryIT
+    - DefaultSslEngineFactoryPropertyBasedWithClientAuthIT
+    - DefaultSslEngineFactoryWithClientAuthIT
+    - DefaultSslEngineFactoryHostnameValidationIT
+    - ProgrammaticSslIT
+    - DefaultSslEngineFactoryPropertyBasedIT
+
+    # error: unrecognised option '-Dcassandra.superuser_setup_delay_ms=0'
+    - PlainTextAuthProviderIT
+
+    # I don't know if scylla has the same thing for warnings, i.e. noticeable by the driver
+    - ExecutionInfoWarningsIT
+
+    # Can't use nowInSeconds with protocol V4
+    - NowInSecondsIT
+
+    # `crc_check_chance` option is not supported, defaulting to 1.0
+    # See: https://github.com/scylladb/scylladb/blob/7d6f734a519aac9a9a7da84b2ee3a55d11aa1cf4/docs/cql/ddl.rst?plain=1#L924
+    - RelationOptionsIT
+
+    # Ignoring until https://scylladb.atlassian.net/browse/SCYLLADB-745 is resolved
+    - RequestIdGeneratorIT
+
+    # PeersV2NodeRefreshIT fails with BindNodeException on hardcoded port 49152 when
+    # the port is still occupied from a prior test run in the same CI job.
+    # Root cause: NodePerPortResolver missing release() override + shared static singleton.
+    # Fix: https://github.com/scylladb/java-simulacron/pull/5 (issue #4)
+    # TODO: remove this entry once the simulacron fix is released and picked up in the driver pom.xml
+    - PeersV2NodeRefreshIT
+
+    # Flaky timing-based test: preparedStmtCacheRemoveLatch did not trigger before timeout.
+    # Fails intermittently regardless of Scylla version or driver changes.
+    - PreparedStatementCachingIT

--- a/versions/datastax/4.19.3/patch
+++ b/versions/datastax/4.19.3/patch
@@ -1,0 +1,1100 @@
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+index 326c05e..02aac05 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+ import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
+ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+ import com.datastax.oss.driver.categories.ParallelizableTests;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -78,6 +79,7 @@ public class ProtocolVersionInitialNegotiationIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. scylla doesn't support protocol v5 yet")
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+       minInclusive = "4.0-rc1",
+@@ -129,6 +131,7 @@ public class ProtocolVersionInitialNegotiationIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. scylla doesn't support protocol v5 yet")
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+       minInclusive = "2.1",
+@@ -200,6 +203,7 @@ public class ProtocolVersionInitialNegotiationIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. scylla doesn't support protocol v5 yet")
+   /** Note that this test will need to be updated as new protocol versions are introduced. */
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+@@ -266,6 +270,7 @@ public class ProtocolVersionInitialNegotiationIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. V5 protocol checks are not supported in scylla")
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+       minInclusive = "4.0",
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
+index c0cf0b7..08cccf3 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/SessionLeakIT.java
+@@ -44,6 +44,7 @@ import java.util.HashSet;
+ import java.util.Set;
+ import org.junit.Before;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.runner.RunWith;
+@@ -72,6 +73,8 @@ public class SessionLeakIT {
+     // no need to clean up after since this is an isolated test
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. Seems to show incorrect session counts. Possibly polluted by other tests even though isolated?")
+   @Test
+   public void should_warn_when_session_count_exceeds_threshold() {
+     int threshold = 4;
+@@ -110,6 +113,8 @@ public class SessionLeakIT {
+     session.close();
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. Seems to show incorrect session counts. Possibly polluted by other tests even though isolated?")
+   @Test
+   public void should_never_warn_when_session_init_fails() {
+     SIMULACRON_RULE
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
+index 3dad08f..10402b1 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/DirectCompressionIT.java
+@@ -37,6 +37,7 @@ import java.time.Duration;
+ import org.junit.Assume;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -72,6 +73,8 @@ public class DirectCompressionIT {
+    * @test_category connection:compression
+    * @expected_result session established and queries made successfully using it.
+    */
++  @Ignore(
++      "Driver matrix incompatible. init query OPTIONS: unexpected server error [PROTOCOL_ERROR] Unknown compression algorithm")
+   @Test
+   public void should_execute_queries_with_snappy_compression() throws Exception {
+     Assume.assumeTrue(
+@@ -89,6 +92,8 @@ public class DirectCompressionIT {
+    * @test_category connection:compression
+    * @expected_result session established and queries made successfully using it.
+    */
++  @Ignore(
++      "Driver matrix incompatible. init query OPTIONS: unexpected server error [PROTOCOL_ERROR] Unknown compression algorithm)")
+   @Test
+   public void should_execute_queries_with_lz4_compression() throws Exception {
+     createAndCheckCluster("lz4");
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
+index a14c3b2..8edf291 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/compression/HeapCompressionIT.java
+@@ -37,6 +37,7 @@ import java.time.Duration;
+ import org.junit.Assume;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -76,6 +77,8 @@ public class HeapCompressionIT {
+    * @test_category connection:compression
+    * @expected_result session established and queries made successfully using it.
+    */
++  @Ignore(
++      "Driver matrix incompatible. init query OPTIONS: unexpected server error [PROTOCOL_ERROR] Unknown compression algorithm")
+   @Test
+   public void should_execute_queries_with_snappy_compression() throws Exception {
+     Assume.assumeTrue(
+@@ -91,6 +94,8 @@ public class HeapCompressionIT {
+    * @test_category connection:compression
+    * @expected_result session established and queries made successfully using it.
+    */
++  @Ignore(
++      "Driver matrix incompatible. init query OPTIONS: unexpected server error [PROTOCOL_ERROR] Unknown compression algorithm")
+   @Test
+   public void should_execute_queries_with_lz4_compression() throws Exception {
+     createAndCheckCluster("lz4");
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+index 8b65263..4342dbc 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+@@ -43,6 +43,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
+ import java.util.Iterator;
+ import java.util.List;
+ import org.junit.Before;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -239,6 +240,7 @@ public class BatchStatementIT {
+     verifyBatchInsert();
+   }
+ 
++  @Ignore("ServerError: Not implemented: LWT")
+   @Test
+   public void should_execute_cas_batch() {
+     // Build a batch with CAS operations on the same partition.
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+index 9e4b62c..276be70 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+@@ -62,6 +62,7 @@ import java.util.Map;
+ import java.util.concurrent.CompletionStage;
+ import java.util.function.Function;
+ import org.junit.Before;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -282,6 +283,7 @@ public class BoundStatementCcmIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. Scylla doesn't support customPayload in CQL\n")
+   @Test
+   public void should_propagate_attributes_when_preparing_a_simple_statement() {
+     CqlSession session = sessionRule.session();
+@@ -378,6 +380,8 @@ public class BoundStatementCcmIT {
+     }
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. skipping cause of https://github.com/scylladb/scylla/issues/10956\n")
+   @Test
+   public void should_set_all_occurrences_of_variable() {
+     CqlSession session = sessionRule.session();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
+index 9eb8831..90de52f 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PerRequestKeyspaceIT.java
+@@ -40,6 +40,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
+ import java.nio.ByteBuffer;
+ import java.time.Duration;
+ import org.junit.Before;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -126,6 +127,8 @@ public class PerRequestKeyspaceIT {
+     }
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_execute_simple_statement_with_keyspace() {
+@@ -144,6 +147,8 @@ public class PerRequestKeyspaceIT {
+     assertThat(row.getInt(0)).isEqualTo(1);
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_execute_batch_with_explicit_keyspace() {
+@@ -168,6 +173,8 @@ public class PerRequestKeyspaceIT {
+     assertThat(row.getInt(0)).isEqualTo(1);
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_execute_batch_with_inferred_keyspace() {
+@@ -200,6 +207,8 @@ public class PerRequestKeyspaceIT {
+     assertThat(row.getInt(0)).isEqualTo(1);
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_prepare_statement_with_keyspace() {
+@@ -220,6 +229,8 @@ public class PerRequestKeyspaceIT {
+     assertThat(row.getInt(0)).isEqualTo(1);
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_reprepare_statement_with_keyspace_on_the_fly() {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+index 6eb1a7d..719b7c7 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+@@ -49,6 +49,7 @@ import org.junit.After;
+ import org.junit.AfterClass;
+ import org.junit.Before;
+ import org.junit.BeforeClass;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -190,6 +191,8 @@ public class PreparedStatementCancellationIT {
+   // documents the fact that the current driver impl will behave in this way.  We should probably
+   // consider changing this in a future release, although it's worthwhile fully considering the
+   // implications of such a change.
++  @Ignore(
++      "Driver matrix incompatible. Flaky, cache may remove this entry before the comparison and fail. Failure consistent when adding sleep before verify. Passes when run locally without sleep.")
+   @Test
+   public void will_cache_invalid_cql() throws Exception {
+ 
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+index 5671a76..88db15e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+@@ -53,6 +53,7 @@ import java.util.concurrent.CompletionStage;
+ import junit.framework.TestCase;
+ import org.assertj.core.api.AbstractThrowableAssert;
+ import org.junit.Before;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -148,6 +149,7 @@ public class PreparedStatementIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. No reason was listed")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_update_metadata_when_schema_changed_across_executions() {
+@@ -177,6 +179,8 @@ public class PreparedStatementIT {
+     }
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. java.lang.IllegalArgumentException: Can't use per-request keyspace with protocol V4. This reason was listed but may be incorrect.")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_update_metadata_when_schema_changed_across_pages() {
+@@ -222,6 +226,7 @@ public class PreparedStatementIT {
+     assertThat(ps.getResultSetDefinitions().get("d").getType()).isEqualTo(DataTypes.INT);
+   }
+ 
++  @Ignore("Driver matrix incompatible. No reason was listed")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_update_metadata_when_schema_changed_across_sessions() {
+@@ -269,6 +274,8 @@ public class PreparedStatementIT {
+     session2.close();
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. expected \"Undefined column name d\" and got \"Undefined name d\"")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_fail_to_reprepare_if_query_becomes_invalid() {
+@@ -288,12 +295,14 @@ public class PreparedStatementIT {
+         .hasMessageContaining("Undefined column name d");
+   }
+ 
++  @Ignore("Driver matrix incompatible. No reason was listed")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "4.0")
+   public void should_not_store_metadata_for_conditional_updates() {
+     should_not_store_metadata_for_conditional_updates(sessionRule.session());
+   }
+ 
++  @Ignore("ServerError: Not implemented: LWT")
+   @Test
+   @BackendRequirement(type = BackendType.CASSANDRA, minInclusive = "2.2")
+   public void should_not_store_metadata_for_conditional_updates_in_legacy_protocol() {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+index 37a600e..74ff340 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+@@ -34,6 +34,7 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
+ import java.net.InetAddress;
+ import java.net.InetSocketAddress;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -66,6 +67,7 @@ public class QueryTraceIT {
+         .hasMessage("Tracing was disabled for this request");
+   }
+ 
++  @Ignore("Driver matrix incompatible. Undefined name coordinator_port in selection clause")
+   @Test
+   public void should_fetch_trace_when_tracing_enabled() {
+     ExecutionInfo executionInfo =
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
+index 77a449d..b41749f 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/reactive/DefaultReactiveResultSetIT.java
+@@ -47,6 +47,7 @@ import java.util.Set;
+ import org.junit.Before;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -176,6 +177,7 @@ public class DefaultReactiveResultSetIT {
+     assertThat(wasApplied).hasSize(1).containsExactly(true);
+   }
+ 
++  @Ignore("Driver matrix incompatible. No reason listed.")
+   @Test
+   public void should_write_cas() {
+     SimpleStatement statement =
+@@ -234,6 +236,7 @@ public class DefaultReactiveResultSetIT {
+     assertThat(wasApplied).hasSize(1).containsExactly(row.wasApplied());
+   }
+ 
++  @Ignore("Driver matrix incompatible. No reason listed.")
+   @Test
+   public void should_write_batch_cas() {
+     BatchStatement batch = createCASBatch();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+index af454fc..e3b0e33 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+@@ -53,6 +53,7 @@ import java.util.Set;
+ import java.util.concurrent.TimeUnit;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.rules.RuleChain;
+ import org.junit.rules.TestRule;
+@@ -234,6 +235,8 @@ public class DefaultLoadBalancingPolicyIT {
+     }
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. test wrongly assume all nodes are on 127.0.0.1 except node5 from dc2\n")
+   @Test
+   public void should_apply_node_filter() {
+     Set<Node> localNodes = new HashSet<>();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
+index f80b022..93ede4d 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/CaseSensitiveUdtIT.java
+@@ -31,6 +31,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+ import com.datastax.oss.driver.categories.ParallelizableTests;
+ import java.time.Duration;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -61,6 +62,7 @@ public class CaseSensitiveUdtIT {
+   @ClassRule
+   public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+ 
++  @Ignore("Driver matrix incompatible. InvalidQueryException: Unknown type ks_17.address")
+   @Test
+   public void should_expose_metadata_with_correct_case() {
+     boolean supportsFunctions = CCM_RULE.getCassandraVersion().compareTo(Version.V2_2_0) >= 0;
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+index 8f5680f..c645f80 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/NodeMetadataIT.java
+@@ -38,6 +38,7 @@ import java.net.InetSocketAddress;
+ import java.util.Collection;
+ import java.util.Set;
+ import java.util.concurrent.TimeUnit;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -47,6 +48,8 @@ public class NodeMetadataIT {
+ 
+   @Rule public CcmRule ccmRule = CcmRule.getInstance();
+ 
++  @Ignore(
++      "Driver matrix incompatible. expecting scylla to report 3.11.0 as CQL version, scylla report 3.0.8 for now")
+   @Test
+   public void should_expose_node_metadata() {
+     try (CqlSession session = SessionUtils.newSession(ccmRule)) {
+@@ -61,7 +64,7 @@ public class NodeMetadataIT {
+                   assertThat(broadcastAddress.getAddress()).isEqualTo(connectAddress.getAddress()));
+       assertThat(node.getListenAddress().get().getAddress()).isEqualTo(connectAddress.getAddress());
+       assertThat(node.getDatacenter()).isEqualTo("dc1");
+-      assertThat(node.getRack()).isEqualTo("r1");
++      assertThat(node.getRack()).isEqualTo("RAC1");
+       if (CcmBridge.isDistributionOf(BackendType.CASSANDRA)) {
+         // CcmBridge does not report accurate C* versions for other distributions (e.g. DSE), only
+         // approximated values
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
+index 724508d..8a85d32 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaAgreementIT.java
+@@ -30,6 +30,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+ import java.time.Duration;
+ import java.util.concurrent.atomic.AtomicInteger;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.rules.RuleChain;
+@@ -65,6 +66,8 @@ public class SchemaAgreementIT {
+     assertThat(SESSION_RULE.session().checkSchemaAgreement()).isTrue();
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. pause/resume scylla doesn't immediately have schema disagreement")
+   @Test
+   public void should_fail_on_timeout() {
+     CCM_RULE.getCcmBridge().pause(2);
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+index 85fcfc0..e1dab54 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaChangesIT.java
+@@ -47,6 +47,7 @@ import java.util.function.Consumer;
+ import java.util.function.Function;
+ import org.junit.Before;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.rules.RuleChain;
+ import org.junit.rules.TestRule;
+@@ -93,16 +94,15 @@ public class SchemaChangesIT {
+         null,
+         String.format(
+             "CREATE KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+             newKeyspaceId),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+         keyspace -> {
+           assertThat(keyspace.getName()).isEqualTo(newKeyspaceId);
+           assertThat(keyspace.isDurableWrites()).isTrue();
+           assertThat(keyspace.getReplication())
+-              .hasSize(2)
+-              .containsEntry("class", "org.apache.cassandra.locator.SimpleStrategy")
+-              .containsEntry("replication_factor", "1");
++              .containsEntry("class", "org.apache.cassandra.locator.NetworkTopologyStrategy")
++              .containsEntry("dc1", "1");
+         },
+         (listener, keyspace) -> verify(listener).onKeyspaceCreated(keyspace),
+         newKeyspaceId);
+@@ -115,7 +115,7 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format("DROP KEYSPACE %s", newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -130,11 +130,11 @@ public class SchemaChangesIT {
+         ImmutableList.of(
+             String.format(
+                 "CREATE KEYSPACE %s "
+-                    + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 newKeyspaceId.asCql(true))),
+         String.format(
+             "ALTER KEYSPACE %s "
+-                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} "
++                + "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} "
+                 + "AND durable_writes = 'false'",
+             newKeyspaceId.asCql(true)),
+         metadata -> metadata.getKeyspace(newKeyspaceId),
+@@ -260,8 +260,9 @@ public class SchemaChangesIT {
+           assertThat(view.getName().asInternal()).isEqualTo("highscores");
+           assertThat(view.getBaseTable().asInternal()).isEqualTo("scores");
+           assertThat(view.includesAllColumns()).isFalse();
+-          assertThat(view.getWhereClause())
+-              .hasValue("game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL");
++          assertThat(view.getWhereClause().get().toLowerCase())
++              .isEqualTo(
++                  "game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL".toLowerCase());
+           assertThat(view.getColumns())
+               .containsOnlyKeys(
+                   CqlIdentifier.fromInternal("game"),
+@@ -271,6 +272,7 @@ public class SchemaChangesIT {
+         (listener, view) -> verify(listener).onViewCreated(view));
+   }
+ 
++  @Ignore("Driver matrix incompatible. wrong case of NULL is returned in schema of MV")
+   @Test
+   public void should_handle_view_drop() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V3_0_0) >= 0)
+@@ -314,6 +316,8 @@ public class SchemaChangesIT {
+         (listener, oldView, newView) -> verify(listener).onViewUpdated(newView, oldView));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_function_creation() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+@@ -338,6 +342,8 @@ public class SchemaChangesIT {
+         (listener, function) -> verify(listener).onFunctionCreated(function));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_function_drop() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+@@ -354,6 +360,8 @@ public class SchemaChangesIT {
+         (listener, oldFunction) -> verify(listener).onFunctionDropped(oldFunction));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_function_update() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+@@ -374,6 +382,8 @@ public class SchemaChangesIT {
+             verify(listener).onFunctionUpdated(newFunction, oldFunction));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_aggregate_creation() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+@@ -400,6 +410,8 @@ public class SchemaChangesIT {
+         (listener, aggregate) -> verify(listener).onAggregateCreated(aggregate));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_aggregate_drop() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+@@ -417,6 +429,8 @@ public class SchemaChangesIT {
+         (listener, oldAggregate) -> verify(listener).onAggregateDropped(oldAggregate));
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. 'java isn't supported for scylla user defined functions and aggregations'")
+   @Test
+   public void should_handle_aggregate_update() {
+     assumeThat(CCM_RULE.getCcmBridge().getCassandraVersion().compareTo(Version.V2_2_0) >= 0)
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+index 728bd3c..a0a81a5 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+@@ -47,6 +47,7 @@ import java.util.Map;
+ import java.util.Objects;
+ import java.util.concurrent.TimeUnit;
+ import org.junit.AssumptionViolatedException;
++import org.junit.Ignore;
+ import org.junit.Rule;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+@@ -188,6 +189,7 @@ public class SchemaIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. java.util.NoSuchElementException: No value present")
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+       minInclusive = "4.0",
+@@ -302,6 +304,7 @@ public class SchemaIT {
+     }
+   }
+ 
++  @Ignore("Driver matrix incompatible. java.util.NoSuchElementException: No value present")
+   @BackendRequirement(
+       type = BackendType.CASSANDRA,
+       minInclusive = "4.0",
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+index 057461a..393b968 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/TokenITBase.java
+@@ -56,10 +56,10 @@ public abstract class TokenITBase {
+     for (String statement :
+         ImmutableList.of(
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 KS1.asCql(false)),
+             String.format(
+-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
++                "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
+                 KS2.asCql(false)),
+ 
+             // Shouldn't really do that, but it makes the rest of the tests a bit prettier.
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+index e018451..c0c0861 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.core.metrics.Metrics;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+ import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+@@ -40,9 +39,9 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+ import java.util.ArrayList;
+ import java.util.List;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class DropwizardMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
+index 1ce3fd1..fdd2ea8 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/AddedNodeIT.java
+@@ -33,6 +33,7 @@ import java.util.Map;
+ import java.util.Set;
+ import java.util.concurrent.TimeUnit;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ 
+ public class AddedNodeIT {
+@@ -40,6 +41,7 @@ public class AddedNodeIT {
+   @ClassRule
+   public static final CustomCcmRule CCM_RULE = CustomCcmRule.builder().withNodes(3).build();
+ 
++  @Ignore("Driver matrix incompatible. No reason was specified in ignore.yaml")
+   @Test
+   public void should_signal_and_create_pool_when_node_gets_added() {
+     AddListener addListener = new AddListener();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
+index e0f3329..66a3d81 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/RemovedNodeIT.java
+@@ -33,6 +33,7 @@ import java.util.Map;
+ import java.util.Set;
+ import java.util.concurrent.TimeUnit;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ 
+ public class RemovedNodeIT {
+@@ -45,6 +46,8 @@ public class RemovedNodeIT {
+           .withNodes(4)
+           .build();
+ 
++  @Ignore(
++      "Driver matrix incompatible. NodeStateListener isn't called with onRemove when node decommissioned")
+   @Test
+   public void should_signal_and_destroy_pool_when_node_gets_removed() {
+     RemovalListener removalListener = new RemovalListener();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+index 30a808e..512da13 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DefaultKeyspaceIT.java
+@@ -75,7 +75,7 @@ public class DefaultKeyspaceIT {
+     session.execute(
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                    "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                     DEFAULT_KEYSPACE))
+             .setExecutionProfile(SESSION_RULE.slowProfile())
+             .build());
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+index 9391c03..5a8e11e 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryKeyspaceAndTableIT.java
+@@ -67,7 +67,7 @@ public class QueryKeyspaceAndTableIT {
+         ImmutableList.of(
+             "CREATE TABLE foo(k int PRIMARY KEY)",
+             String.format(
+-                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
++                "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
+                 OTHER_KEYSPACE.asCql(false)),
+             String.format("CREATE TABLE %s.foo(k int PRIMARY KEY)", OTHER_KEYSPACE.asCql(false)))) {
+       session.execute(
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
+index c6e9091..ddaf74f 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/QueryReturnTypesIT.java
+@@ -54,6 +54,7 @@ import java.util.stream.Stream;
+ import org.junit.Before;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -104,12 +105,14 @@ public class QueryReturnTypesIT {
+     assertThat(dao.findByIdAndRank(1, 1)).isNull();
+   }
+ 
++  @Ignore("ServerError: Not implemented: LWT")
+   @Test
+   public void should_execute_conditional_query_and_map_to_boolean() {
+     assertThat(dao.deleteIfExists(1, 1)).isTrue();
+     assertThat(dao.deleteIfExists(1, 1)).isFalse();
+   }
+ 
++  @Ignore("ServerError: Not implemented: LWT")
+   @Test
+   public void should_execute_async_conditional_query_and_map_to_boolean() {
+     assertThat(CompletableFutures.getUninterruptibly(dao.deleteIfExistsAsync(1, 1))).isTrue();
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+index 3eb40fd..df1a5e4 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectOtherClausesIT.java
+@@ -46,6 +46,7 @@ import java.util.Map;
+ import java.util.Objects;
+ import org.junit.BeforeClass;
+ import org.junit.ClassRule;
++import org.junit.Ignore;
+ import org.junit.Test;
+ import org.junit.experimental.categories.Category;
+ import org.junit.rules.RuleChain;
+@@ -101,6 +102,8 @@ public class SelectOtherClausesIT {
+     assertThat(elements.getAvailableWithoutFetching()).isEqualTo(1);
+   }
+ 
++  @Ignore(
++      "Driver matrix incompatible. https://github.com/scylladb/scylla/issues/10008, scylla can return empty page, this test isn't expecting")
+   @Test
+   public void should_select_with_per_partition_limit() {
+     PagingIterable<Simple> elements = dao.selectWithPerPartitionLimit(5);
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+index c38df1e..29479f2 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -40,9 +39,9 @@ import io.micrometer.core.instrument.Tag;
+ import io.micrometer.core.instrument.Timer;
+ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicrometerMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+index aa04c05..5d0a67f 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
+ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+-import com.datastax.oss.driver.categories.ParallelizableTests;
+ import com.datastax.oss.driver.core.metrics.MetricsITBase;
+ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+ import com.datastax.oss.driver.internal.core.metrics.MetricId;
+@@ -44,9 +43,9 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
+ import org.eclipse.microprofile.metrics.Tag;
+ import org.eclipse.microprofile.metrics.Timer;
+ import org.junit.ClassRule;
+-import org.junit.experimental.categories.Category;
+ 
+-@Category(ParallelizableTests.class)
++// Not parallelizable because of unsynchronized concurrent access to the
++// AbstractMetricUpdater.MIN_EXPIRE_AFTER
+ public class MicroProfileMetricsIT extends MetricsITBase {
+ 
+   @ClassRule
+diff --git a/test-infra/revapi.json b/test-infra/revapi.json
+index a16d06d..1edb0fa 100644
+--- a/test-infra/revapi.json
++++ b/test-infra/revapi.json
+@@ -17,6 +17,16 @@
+       }
+     },
+     "ignore": [
++      {
++        "code": "java.method.removed",
++        "old": "method com.datastax.oss.driver.api.testinfra.ccm.CcmBridge.Builder com.datastax.oss.driver.api.testinfra.ccm.CcmBridge.Builder::withIpPrefix(java.lang.String)",
++        "justification": "Scylla CCM support"
++      },
++      {
++        "code": "java.method.removed",
++        "old": "method com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule.Builder com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule.Builder::withIpPrefix(java.lang.String)",
++        "justification": "Scylla CCM support"
++      }
+     ]
+   }
+ }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+index 882cd55..8baa4ed 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+@@ -20,9 +20,14 @@ package com.datastax.oss.driver.api.testinfra.ccm;
+ import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+ import com.datastax.oss.driver.api.core.ProtocolVersion;
+ import com.datastax.oss.driver.api.core.Version;
++import com.datastax.oss.driver.api.core.metadata.EndPoint;
+ import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
+ import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirementRule;
+ import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
++import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
++import java.net.InetSocketAddress;
++import java.util.Collections;
++import java.util.Set;
+ import org.junit.AssumptionViolatedException;
+ import org.junit.runner.Description;
+ import org.junit.runners.model.Statement;
+@@ -56,6 +61,13 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
+     ccmBridge.close();
+   }
+ 
++  @Override
++  public Set<EndPoint> getContactPoints() {
++    return Collections.singleton(
++        new DefaultEndPoint(
++            new InetSocketAddress(String.format("127.0.%s.1", ccmBridge.idPrefix), 9042)));
++  }
++
+   @Override
+   public Statement apply(Statement base, Description description) {
+     if (BackendRequirementRule.meetsDescriptionRequirements(description)) {
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+index f0ce6bc..e76d46b 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+@@ -61,6 +61,10 @@ public class CcmBridge implements AutoCloseable {
+   public static final Version VERSION =
+       Objects.requireNonNull(Version.parse(System.getProperty("ccm.version", "4.0.0")));
+ 
++  public String idPrefix = "0";
++
++  public static final String SCYLLA_VERSION = System.getProperty("scylla.version");
++
+   public static final String INSTALL_DIRECTORY = System.getProperty("ccm.directory");
+ 
+   public static final String BRANCH = System.getProperty("ccm.branch");
+@@ -124,7 +128,6 @@ public class CcmBridge implements AutoCloseable {
+   private final Path configDirectory;
+   private final AtomicBoolean started = new AtomicBoolean();
+   private final AtomicBoolean created = new AtomicBoolean();
+-  private final String ipPrefix;
+   private final Map<String, Object> cassandraConfiguration;
+   private final Map<String, Object> dseConfiguration;
+   private final List<String> rawDseYaml;
+@@ -135,7 +138,7 @@ public class CcmBridge implements AutoCloseable {
+   private CcmBridge(
+       Path configDirectory,
+       int[] nodes,
+-      String ipPrefix,
++      String idPrefix,
+       Map<String, Object> cassandraConfiguration,
+       Map<String, Object> dseConfiguration,
+       List<String> dseConfigurationRawYaml,
+@@ -151,7 +154,7 @@ public class CcmBridge implements AutoCloseable {
+     } else {
+       this.nodes = nodes;
+     }
+-    this.ipPrefix = ipPrefix;
++    this.idPrefix = idPrefix;
+     this.cassandraConfiguration = cassandraConfiguration;
+     this.dseConfiguration = dseConfiguration;
+     this.rawDseYaml = dseConfigurationRawYaml;
+@@ -196,6 +199,7 @@ public class CcmBridge implements AutoCloseable {
+     return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
+   }
+ 
++  @SuppressWarnings("unused")
+   private String getCcmVersionString(Version version) {
+     // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
+     // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
+@@ -223,14 +227,15 @@ public class CcmBridge implements AutoCloseable {
+         createOptions.add("-v git:" + BRANCH.trim().replaceAll("\"", ""));
+ 
+       } else {
+-        createOptions.add("-v " + getCcmVersionString(VERSION));
++        createOptions.add("-v " + SCYLLA_VERSION);
+       }
+       createOptions.addAll(Arrays.asList(DISTRIBUTION.getCcmOptions()));
+       execute(
+           "create",
+           CLUSTER_NAME,
+-          "-i",
+-          ipPrefix,
++          "--scylla",
++          "--id",
++          idPrefix,
+           "-n",
+           Arrays.stream(nodes).mapToObj(n -> "" + n).collect(Collectors.joining(":")),
+           createOptions.stream().collect(Collectors.joining(" ")));
+@@ -260,6 +265,9 @@ public class CcmBridge implements AutoCloseable {
+                 getConfigKey(originalKey, originalValue, cassandraVersion),
+                 getConfigValue(originalKey, originalValue, cassandraVersion)));
+       }
++      if (getCassandraVersion().compareTo(Version.V2_2_0) >= 0) {
++        execute("updateconf", "enable_user_defined_functions:true", "experimental_features:[udf]");
++      }
+ 
+       // Note that we aren't performing any substitution on DSE key/value props (at least for now)
+       if (isDistributionOf(BackendType.DSE)) {
+@@ -337,8 +345,10 @@ public class CcmBridge implements AutoCloseable {
+ 
+   public void add(int n, String dc) {
+     List<String> addOptions = new ArrayList<>();
+-    addOptions.addAll(Arrays.asList("add", "-i", ipPrefix + n, "-d", dc, "node" + n));
+-    addOptions.addAll(Arrays.asList(DISTRIBUTION.getCcmOptions()));
++    addOptions.addAll(
++        Arrays.asList(
++            "add", "--scylla", "-i", "127.0." + idPrefix + "." + n, "-d", dc, "node" + n));
++    // addOptions.addAll(Arrays.asList(DISTRIBUTION.getCcmOptions()));
+     execute(addOptions.toArray(new String[0]));
+     start(n);
+   }
+@@ -354,6 +364,7 @@ public class CcmBridge implements AutoCloseable {
+             + " --config-dir="
+             + configDirectory.toFile().getAbsolutePath();
+ 
++    LOG.warn("Executing: " + command);
+     execute(CommandLine.parse(command));
+   }
+ 
+@@ -532,7 +543,7 @@ public class CcmBridge implements AutoCloseable {
+     private final Map<String, Object> dseConfiguration = new LinkedHashMap<>();
+     private final List<String> dseRawYaml = new ArrayList<>();
+     private final List<String> jvmArgs = new ArrayList<>();
+-    private String ipPrefix = "127.0.0.";
++    private String idPrefix = "0";
+     private final List<String> createOptions = new ArrayList<>();
+     private final List<String> dseWorkloads = new ArrayList<>();
+ 
+@@ -542,13 +553,13 @@ public class CcmBridge implements AutoCloseable {
+       try {
+         this.configDirectory = Files.createTempDirectory("ccm");
+         // mark the ccm temp directories for deletion when the JVM exits
+-        this.configDirectory.toFile().deleteOnExit();
++        // this.configDirectory.toFile().deleteOnExit();
+       } catch (IOException e) {
+         // change to unchecked for now.
+         throw new RuntimeException(e);
+       }
+       // disable auto_snapshot by default to reduce disk usage when destroying schema.
+-      withCassandraConfiguration("auto_snapshot", "false");
++      // withCassandraConfiguration("auto_snapshot", "false");
+     }
+ 
+     public Builder withCassandraConfiguration(String key, Object value) {
+@@ -576,8 +587,8 @@ public class CcmBridge implements AutoCloseable {
+       return this;
+     }
+ 
+-    public Builder withIpPrefix(String ipPrefix) {
+-      this.ipPrefix = ipPrefix;
++    public Builder withIdPrefix(String idPrefix) {
++      this.idPrefix = idPrefix;
+       return this;
+     }
+ 
+@@ -629,7 +640,7 @@ public class CcmBridge implements AutoCloseable {
+       return new CcmBridge(
+           configDirectory,
+           nodes,
+-          ipPrefix,
++          idPrefix,
+           cassandraConfiguration,
+           dseConfiguration,
+           dseRawYaml,
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+index 5ea1bf7..1e26ec4 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+@@ -17,6 +17,7 @@
+  */
+ package com.datastax.oss.driver.api.testinfra.ccm;
+ 
++import java.util.concurrent.atomic.AtomicInteger;
+ import java.util.concurrent.atomic.AtomicReference;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+@@ -35,6 +36,8 @@ public class CustomCcmRule extends BaseCcmRule {
+   private static final Logger LOG = LoggerFactory.getLogger(CustomCcmRule.class);
+   private static final AtomicReference<CustomCcmRule> CURRENT = new AtomicReference<>();
+ 
++  private static AtomicInteger cluster_id = new AtomicInteger(1);
++
+   CustomCcmRule(CcmBridge ccmBridge) {
+     super(ccmBridge);
+   }
+@@ -84,6 +87,10 @@ public class CustomCcmRule extends BaseCcmRule {
+ 
+     private final CcmBridge.Builder bridgeBuilder = CcmBridge.builder();
+ 
++    public Builder() {
++      this.withIdPrefix(Integer.toString(cluster_id.incrementAndGet()));
++    }
++
+     public Builder withNodes(int... nodes) {
+       bridgeBuilder.withNodes(nodes);
+       return this;
+@@ -134,6 +141,11 @@ public class CustomCcmRule extends BaseCcmRule {
+       return this;
+     }
+ 
++    public Builder withIdPrefix(String idPrefix) {
++      bridgeBuilder.withIdPrefix(idPrefix);
++      return this;
++    }
++
+     public CustomCcmRule build() {
+       return new CustomCcmRule(bridgeBuilder.build());
+     }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+index 0819f78..16c88c4 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+@@ -28,12 +28,13 @@ public class DefaultCcmBridgeBuilderCustomizer {
+     if (!CcmBridge.isDistributionOf(
+             BackendType.DSE, (dist, cass) -> dist.nextStable().compareTo(Version.V4_0_0) >= 0)
+         || CcmBridge.isDistributionOf(BackendType.HCD)) {
+-      builder.withCassandraConfiguration("enable_materialized_views", true);
+-      builder.withCassandraConfiguration("enable_sasi_indexes", true);
++      // builder.withCassandraConfiguration("enable_materialized_views", true);
++      // builder.withCassandraConfiguration("enable_sasi_indexes", true);
+     }
+     if (CcmBridge.getDistributionVersion().nextStable().compareTo(Version.V3_0_0) >= 0) {
+-      builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
+-      builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
++      // builder.withJvmArgs("-Dcassandra.superuser_setup_delay_ms=0");
++      // builder.withJvmArgs("-Dcassandra.skip_wait_for_gossip_to_settle=0");
++      builder.withCassandraConfiguration("skip_wait_for_gossip_to_settle", "0");
+       builder.withCassandraConfiguration("num_tokens", "1");
+       builder.withCassandraConfiguration("initial_token", "0");
+     }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0f..9672618 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 } AND tablets = {'enabled': false};",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();


### PR DESCRIPTION
## Summary

Upstream released datastax java-driver **4.19.3** ([apache/cassandra-java-driver@4.19.3](https://github.com/apache/cassandra-java-driver/releases/tag/4.19.3)). The existing `versions/datastax/4.19.2/patch` fails to apply to 4.19.3 due to two upstream changes.

This PR adds `versions/datastax/4.19.3/` with a migrated patch and the same `ignore.yaml` from 4.19.2.

## What changed in upstream 4.19.3

### `PreparedStatementCancellationIT.java`

Upstream added ~63 lines: inner classes (`TestCqlPrepareAsyncProcessor`, `TestDefaultDriverContext`, `TestSessionBuilder`), `@BeforeClass`/`@AfterClass` methods, and new imports. This shifted the context around where our `import org.junit.Ignore` is inserted.

**Fix:** Updated the import insertion point to account for the new imports (`AfterClass`, `BeforeClass`, etc.).

### `test-infra/revapi.json`

Upstream removed all ~174 accumulated API compatibility exclusions, shrinking the file from 196 to 22 lines. The `ignore` array is now empty `[]`. Our patch appended two `withIpPrefix` removal entries after line 190 which no longer exists.

**Fix:** Target the now-empty `"ignore": []` array instead.

### All other files

No upstream changes in any other files touched by our patch — all other hunks carry over from 4.19.2 without modification.

## Validation

| Stage | Status |
|-------|--------|
| `git apply --check` against 4.19.3 tag | ✅ Passed locally |
| Jenkins staging (scylla-master, datastax 4.19.3 only) | ✅ [Build #42](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-master/42/) — passed (29m 50s) |

## Context

Jenkins daily build [#2023](https://jenkins.scylladb.com/job/scylla-master/job/driver-tests/job/java-driver-matrix-test/2023/) failed because the matrix's floor-fallback picked `4.19.2/patch` for the new upstream `4.19.3`, but the patch no longer applies cleanly.