### PR TITLE
fix: drop release: prefix from datastax 4.19.x CCM version strings

### DIFF
--- a/versions/datastax/4.19.2/patch
+++ b/versions/datastax/4.19.2/patch
@@ -916,23 +916,21 @@ index f0ce6bc5b..e76d46b11 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,32 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,36 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  
 +  // Returns the version string for CCM cluster creation when running against ScyllaDB.
-+  // The "release:" prefix is intentionally omitted here. When "release:" is prepended,
-+  // CCM attempts to resolve and download the version from its S3-based release repository,
-+  // which fails in two distinct ways:
-+  //   - Dev/unstable builds (e.g. "2026.3.0~dev"): CCM cannot parse the version and
-+  //     returns "s3 url was not found for :2026.3" (colon from the tilde-split).
-+  //   - Stable-branch builds (e.g. "2025.1.13", "2026.1.5"): CCM finds no matching
-+  //     release package on S3 and raises "ValueError: Release packages have not been found."
-+  // In both cases the CCM cluster never starts and all integration tests fail.
-+  // Jenkins pre-downloads the ScyllaDB relocatable and installs it locally before running
-+  // tests, so CCM must use the locally-installed version -- not fetch a fresh one from S3.
-+  // Passing the raw version string (without any prefix) causes CCM to use the local install.
-+  // This mirrors the fix applied in the scylla driver 4.18.1.0 patch for the same reason.
++  // CCM interprets the prefix before ":" to choose the download source:
++  //   - "release:<version>" → resolves and downloads from the S3 release repository.
++  //   - No prefix          → skips S3 entirely; reads SCYLLA_UNIFIED_PACKAGE from env.
++  // When SCYLLA_UNIFIED_PACKAGE is set, a local tarball is available (e.g. Jenkins
++  // pre-downloads dev/unreleased builds not published to S3). Passing a bare version
++  // causes CCM to use that local file via packages_from_env().
++  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" so
++  // CCM downloads the published release from S3.
++  // This avoids "release:<dev-version>" S3 lookup failures on Jenkins while still
++  // allowing GH Actions to download released versions automatically.
 +  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
 +  // and incorrectly prepended "release:" -- prior to that PR the patches passed SCYLLA_VERSION
 +  // directly and all pipelines were green.
@@ -941,9 +939,14 @@ index f0ce6bc5b..e76d46b11 100644
 +      return getCcmVersionString(VERSION);
 +    }
 +    if (SCYLLA_VERSION.contains(":")) {
++      // Already has a CCM prefix (e.g. "unstable/master:date") — pass through as-is.
 +      return SCYLLA_VERSION;
 +    }
-+    return SCYLLA_VERSION;
++    // Use local tarball when available, otherwise download from S3.
++    if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
++      return SCYLLA_VERSION;
++    }
++    return "release:" + SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {

--- a/versions/datastax/4.19.2/patch
+++ b/versions/datastax/4.19.2/patch
@@ -916,7 +916,7 @@ index f0ce6bc5b..e76d46b11 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,36 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,35 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  

--- a/versions/datastax/4.19.2/patch
+++ b/versions/datastax/4.19.2/patch
@@ -916,18 +916,34 @@ index f0ce6bc5b..e76d46b11 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,16 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,32 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  
++  // Returns the version string for CCM cluster creation when running against ScyllaDB.
++  // The "release:" prefix is intentionally omitted here. When "release:" is prepended,
++  // CCM attempts to resolve and download the version from its S3-based release repository,
++  // which fails in two distinct ways:
++  //   - Dev/unstable builds (e.g. "2026.3.0~dev"): CCM cannot parse the version and
++  //     returns "s3 url was not found for :2026.3" (colon from the tilde-split).
++  //   - Stable-branch builds (e.g. "2025.1.13", "2026.1.5"): CCM finds no matching
++  //     release package on S3 and raises "ValueError: Release packages have not been found."
++  // In both cases the CCM cluster never starts and all integration tests fail.
++  // Jenkins pre-downloads the ScyllaDB relocatable and installs it locally before running
++  // tests, so CCM must use the locally-installed version -- not fetch a fresh one from S3.
++  // Passing the raw version string (without any prefix) causes CCM to use the local install.
++  // This mirrors the fix applied in the scylla driver 4.18.1.0 patch for the same reason.
++  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
++  // and incorrectly prepended "release:" -- prior to that PR the patches passed SCYLLA_VERSION
++  // directly and all pipelines were green.
 +  private String getScyllaCcmVersionString() {
 +    if (SCYLLA_VERSION == null || SCYLLA_VERSION.isEmpty()) {
-+      return "release:" + getCcmVersionString(VERSION);
++      return getCcmVersionString(VERSION);
 +    }
 +    if (SCYLLA_VERSION.contains(":")) {
 +      return SCYLLA_VERSION;
 +    }
-+    return "release:" + SCYLLA_VERSION;
++    return SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {

--- a/versions/datastax/4.19.3/patch
+++ b/versions/datastax/4.19.3/patch
@@ -916,18 +916,34 @@ index f0ce6bc..e76d46b 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,16 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,32 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  
++  // Returns the version string for CCM cluster creation when running against ScyllaDB.
++  // The "release:" prefix is intentionally omitted here. When "release:" is prepended,
++  // CCM attempts to resolve and download the version from its S3-based release repository,
++  // which fails in two distinct ways:
++  //   - Dev/unstable builds (e.g. "2026.3.0~dev"): CCM cannot parse the version and
++  //     returns "s3 url was not found for :2026.3" (colon from the tilde-split).
++  //   - Stable-branch builds (e.g. "2025.1.13", "2026.1.5"): CCM finds no matching
++  //     release package on S3 and raises "ValueError: Release packages have not been found."
++  // In both cases the CCM cluster never starts and all integration tests fail.
++  // Jenkins pre-downloads the ScyllaDB relocatable and installs it locally before running
++  // tests, so CCM must use the locally-installed version -- not fetch a fresh one from S3.
++  // Passing the raw version string (without any prefix) causes CCM to use the local install.
++  // This mirrors the fix applied in the scylla driver 4.18.1.0 patch for the same reason.
++  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
++  // and incorrectly prepended "release:" -- prior to that PR the patches passed SCYLLA_VERSION
++  // directly and all pipelines were green.
 +  private String getScyllaCcmVersionString() {
 +    if (SCYLLA_VERSION == null || SCYLLA_VERSION.isEmpty()) {
-+      return "release:" + getCcmVersionString(VERSION);
++      return getCcmVersionString(VERSION);
 +    }
 +    if (SCYLLA_VERSION.contains(":")) {
 +      return SCYLLA_VERSION;
 +    }
-+    return "release:" + SCYLLA_VERSION;
++    return SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {

--- a/versions/datastax/4.19.3/patch
+++ b/versions/datastax/4.19.3/patch
@@ -916,23 +916,21 @@ index f0ce6bc..e76d46b 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,32 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,36 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  
 +  // Returns the version string for CCM cluster creation when running against ScyllaDB.
-+  // The "release:" prefix is intentionally omitted here. When "release:" is prepended,
-+  // CCM attempts to resolve and download the version from its S3-based release repository,
-+  // which fails in two distinct ways:
-+  //   - Dev/unstable builds (e.g. "2026.3.0~dev"): CCM cannot parse the version and
-+  //     returns "s3 url was not found for :2026.3" (colon from the tilde-split).
-+  //   - Stable-branch builds (e.g. "2025.1.13", "2026.1.5"): CCM finds no matching
-+  //     release package on S3 and raises "ValueError: Release packages have not been found."
-+  // In both cases the CCM cluster never starts and all integration tests fail.
-+  // Jenkins pre-downloads the ScyllaDB relocatable and installs it locally before running
-+  // tests, so CCM must use the locally-installed version -- not fetch a fresh one from S3.
-+  // Passing the raw version string (without any prefix) causes CCM to use the local install.
-+  // This mirrors the fix applied in the scylla driver 4.18.1.0 patch for the same reason.
++  // CCM interprets the prefix before ":" to choose the download source:
++  //   - "release:<version>" → resolves and downloads from the S3 release repository.
++  //   - No prefix          → skips S3 entirely; reads SCYLLA_UNIFIED_PACKAGE from env.
++  // When SCYLLA_UNIFIED_PACKAGE is set, a local tarball is available (e.g. Jenkins
++  // pre-downloads dev/unreleased builds not published to S3). Passing a bare version
++  // causes CCM to use that local file via packages_from_env().
++  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" so
++  // CCM downloads the published release from S3.
++  // This avoids "release:<dev-version>" S3 lookup failures on Jenkins while still
++  // allowing GH Actions to download released versions automatically.
 +  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
 +  // and incorrectly prepended "release:" -- prior to that PR the patches passed SCYLLA_VERSION
 +  // directly and all pipelines were green.
@@ -941,9 +939,14 @@ index f0ce6bc..e76d46b 100644
 +      return getCcmVersionString(VERSION);
 +    }
 +    if (SCYLLA_VERSION.contains(":")) {
++      // Already has a CCM prefix (e.g. "unstable/master:date") — pass through as-is.
 +      return SCYLLA_VERSION;
 +    }
-+    return SCYLLA_VERSION;
++    // Use local tarball when available, otherwise download from S3.
++    if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
++      return SCYLLA_VERSION;
++    }
++    return "release:" + SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {

--- a/versions/datastax/4.19.3/patch
+++ b/versions/datastax/4.19.3/patch
@@ -916,7 +916,7 @@ index f0ce6bc..e76d46b 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -196,6 +199,36 @@ public class CcmBridge implements AutoCloseable {
+@@ -196,6 +199,35 @@ public class CcmBridge implements AutoCloseable {
      return DistributionCassandraVersions.getCassandraVersion(DISTRIBUTION, VERSION);
    }
  

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -449,15 +449,20 @@ index 7b4d28cedf..88fe5b9809 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -329,7 +332,10 @@ public class CcmBridge implements AutoCloseable {
+@@ -329,7 +332,13 @@ public class CcmBridge implements AutoCloseable {
        if (shouldReplace) {
          versionString = versionString.replace(".0-", ".");
        }
 -      return "release:" + versionString;
-+      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
-+      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
-+      // proven difficult.
-+      return versionString;
++      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
++      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
++      // bare version string so CCM resolves via packages_from_env() and uses the local file.
++      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
++      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
++        return versionString;
++      }
++      return "release:" + versionString;
      }
      // for 4.0 pre-releases, the CCM version string needs to be "4.0-alpha1" or "4.0-alpha2"
      // Version.toString() always adds a patch value, even if it's not specified when parsing.

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -449,7 +449,7 @@ index 7b4d28cedf..88fe5b9809 100644
      this.cassandraConfiguration = cassandraConfiguration;
      this.dseConfiguration = dseConfiguration;
      this.rawDseYaml = dseConfigurationRawYaml;
-@@ -329,7 +332,13 @@ public class CcmBridge implements AutoCloseable {
+@@ -329,7 +332,15 @@ public class CcmBridge implements AutoCloseable {
        if (shouldReplace) {
          versionString = versionString.replace(".0-", ".");
        }

--- a/versions/scylla/4.19.0.8/patch
+++ b/versions/scylla/4.19.0.8/patch
@@ -529,7 +529,18 @@ index e7b2b4e4a..a4b2ecea7 100644
    }
  
    // Copied from Netty's PlatformDependent to avoid the dependency on Netty
-@@ -503,7 +506,18 @@ public class CcmBridge implements AutoCloseable {
+@@ -343,7 +346,9 @@
+       if (shouldReplace) {
+         versionString = versionString.replace(".0-", ".");
+       }
+-      return "release:" + versionString;
++      // Dropping "release:" prefix so CCM uses the locally-installed Scylla package instead of
++      // attempting to download from S3. See versions/scylla/4.18.1.0/patch for the same fix.
++      return versionString;
+     }
+     // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
+     // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
+ @@ -503,7 +506,18 @@ public class CcmBridge implements AutoCloseable {
    }
  
    public void addWithoutStart(int n, String dc) {

--- a/versions/scylla/4.19.0.8/patch
+++ b/versions/scylla/4.19.0.8/patch
@@ -540,7 +540,7 @@ index e7b2b4e4a..a4b2ecea7 100644
      }
      // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
      // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
- @@ -503,7 +506,18 @@ public class CcmBridge implements AutoCloseable {
+@@ -503,7 +508,18 @@ public class CcmBridge implements AutoCloseable {
    }
  
    public void addWithoutStart(int n, String dc) {

--- a/versions/scylla/4.19.0.8/patch
+++ b/versions/scylla/4.19.0.8/patch
@@ -529,18 +529,7 @@ index e7b2b4e4a..a4b2ecea7 100644
    }
  
    // Copied from Netty's PlatformDependent to avoid the dependency on Netty
-@@ -343,7 +346,9 @@
-       if (shouldReplace) {
-         versionString = versionString.replace(".0-", ".");
-       }
--      return "release:" + versionString;
-+      // Dropping "release:" prefix so CCM uses the locally-installed Scylla package instead of
-+      // attempting to download from S3. See versions/scylla/4.18.1.0/patch for the same fix.
-+      return versionString;
-     }
-     // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
-     // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
-@@ -503,7 +508,18 @@ public class CcmBridge implements AutoCloseable {
+@@ -503,7 +506,18 @@ public class CcmBridge implements AutoCloseable {
    }
  
    public void addWithoutStart(int n, String dc) {

--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -207,14 +207,20 @@ index e7b2b4e4a0..8fbbed8d95 100644
    }
  
    // Copied from Netty's PlatformDependent to avoid the dependency on Netty
-@@ -343,7 +346,9 @@
+@@ -343,7 +346,13 @@
        if (shouldReplace) {
          versionString = versionString.replace(".0-", ".");
        }
 -      return "release:" + versionString;
-+      // Dropping "release:" prefix so CCM uses the locally-installed Scylla package instead of
-+      // attempting to download from S3. See versions/scylla/4.18.1.0/patch for the same fix.
-+      return versionString;
++      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
++      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
++      // bare version string so CCM resolves via packages_from_env() and uses the local file.
++      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
++      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
++        return versionString;
++      }
++      return "release:" + versionString;
      }
      // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
      // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when

--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -207,7 +207,7 @@ index e7b2b4e4a0..8fbbed8d95 100644
    }
  
    // Copied from Netty's PlatformDependent to avoid the dependency on Netty
-@@ -343,7 +346,13 @@
+@@ -343,7 +346,15 @@
        if (shouldReplace) {
          versionString = versionString.replace(".0-", ".");
        }

--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -218,7 +218,7 @@ index e7b2b4e4a0..8fbbed8d95 100644
      }
      // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
      // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
- @@ -503,7 +509,18 @@ public class CcmBridge implements AutoCloseable {
+@@ -503,7 +508,18 @@ public class CcmBridge implements AutoCloseable {
    }
  
    public void addWithoutStart(int n, String dc) {

--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -207,7 +207,18 @@ index e7b2b4e4a0..8fbbed8d95 100644
    }
  
    // Copied from Netty's PlatformDependent to avoid the dependency on Netty
-@@ -503,7 +509,18 @@ public class CcmBridge implements AutoCloseable {
+@@ -343,7 +346,9 @@
+       if (shouldReplace) {
+         versionString = versionString.replace(".0-", ".");
+       }
+-      return "release:" + versionString;
++      // Dropping "release:" prefix so CCM uses the locally-installed Scylla package instead of
++      // attempting to download from S3. See versions/scylla/4.18.1.0/patch for the same fix.
++      return versionString;
+     }
+     // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
+     // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
+ @@ -503,7 +509,18 @@ public class CcmBridge implements AutoCloseable {
    }
  
    public void addWithoutStart(int n, String dc) {


### PR DESCRIPTION
## Problem

Fixes regression introduced by #147 — restoring the `release:` prefix broke Jenkins CI.

PR #147 added `release:` prefix to CCM version strings so that GH Actions CI would trigger an S3 download. However, this breaks Jenkins CI where `SCYLLA_UNIFIED_PACKAGE` is set to a local tarball: passing `release:<dev-version>` (e.g. `release:2026.3.0~dev`) triggers an S3 lookup that fails because dev builds are never published to S3.

The opposite is also true: without `release:`, GH Actions falls through to `packages_from_env()` with `url=None` → `TypeError` crash.

### Root cause

CCM's `scylla_repository.py` routes based on colon-prefix:
- `release:<version>` → S3 download path
- `<bare-version>` → `packages_from_env()` (uses `SCYLLA_UNIFIED_PACKAGE` env var)

The patches need to emit `release:<version>` when no local tarball is available (GH Actions), and a bare version when a local tarball is present (Jenkins).

## Fix

Add conditional `release:` prefix logic to the affected `getCcmVersionString()` / `getScyllaCcmVersionString()` methods in all patched driver versions:

```java
if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
    // Jenkins: local tarball present — CCM must use packages_from_env(), bare version required
    return versionString;
} else {
    // GH Actions: no local tarball — CCM must download from S3, release: prefix required
    return "release:" + versionString;
}
```

The `SCYLLA_UNIFIED_PACKAGE` env var is the exact signal that a local tarball exists (set by Jenkins pipeline, never set in GH Actions). It is exported into the Docker environment by `run_test.sh` and visible to the Java process.

## Files changed

- `versions/scylla/4.18.1.0/patch`
- `versions/scylla/4.19.0.9/patch`
- `versions/datastax/4.19.2/patch`
- `versions/datastax/4.19.3/patch`

(`versions/scylla/4.19.0.8/patch` is left unchanged — not in any pipeline's test matrix.)

## CI Results

| Environment | Job / Run | Result |
|---|---|---|
| GH Actions | [run 26846786395](https://github.com/scylladb/scylla-java-driver-matrix/actions/runs/26846786395) — scylla 4.18.1.0, 4.19.0.9, datastax 4.19.2, 4.19.3 | ✅ SUCCESS |
| Jenkins staging master | [java-driver-matrix-master #47](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-master/47/) | ✅ SUCCESS |
| Jenkins staging 2026.2 | [java-driver-matrix-2026.2 #6](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-2026.2/6/) | ✅ SUCCESS |
| Jenkins staging 2026.1 | [java-driver-matrix-2026.1 #6](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-2026.1/6/) | ✅ SUCCESS |
| Jenkins staging 2025.4 | [java-driver-matrix-2025.4 #20](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-2025.4/20/) | ✅ SUCCESS |
