### PR TITLE
fix: remove explicit name from current-workflow matrix job

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -125,7 +125,10 @@ jobs:
       scylla_version: ${{ matrix.scylla_version }}
 
   changed-driver-version-tests:
-    name: ${{ matrix.driver_type }} ${{ matrix.driver_version }} / Scylla LATEST
+    # No explicit name for the same reason as current-workflow above: when skipped
+    # (version_count == 0), GitHub would display the unevaluated template string
+    # "${{ matrix.driver_type }} ${{ matrix.driver_version }} / Scylla LATEST".
+    # Without a name, GitHub uses the job ID and auto-appends matrix values when running.
     needs: changes
     if: ${{ needs.changes.outputs.version_count != '0' }}
     strategy:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -91,7 +91,12 @@ jobs:
           echo "scripts/image was updated."
 
   current-workflow:
-    name: ${{ matrix.driver_type }} / Scylla ${{ matrix.scylla_version }}
+    # No explicit name: when this job is skipped (runner_changed == false), GitHub Actions
+    # collapses the entire matrix to a single UI entry and displays the job name with
+    # unevaluated template variables (e.g. "${{ matrix.driver_type }} / Scylla
+    # ${{ matrix.scylla_version }}"). With no name field, GitHub falls back to the job ID
+    # ("current-workflow") when skipped, and auto-appends matrix values per row when running:
+    # e.g. "current-workflow (datastax, LATEST) / integration-test".
     needs: changes
     if: ${{ needs.changes.outputs.runner_changed == 'true' }}
     strategy:


### PR DESCRIPTION
## Problem

Two matrix jobs in `pr-integration-tests.yml` define explicit `name` fields using `${{ matrix.* }}` expressions. When a matrix job is skipped (its `if` condition is false), GitHub Actions collapses the entire matrix to a **single UI entry** without instantiating the matrix — so template variables are never evaluated and appear literally in the job list.

### `current-workflow` (skipped when `runner_changed == false`)

| State | Before | After |
|---|---|---|
| Skipped | `${{ matrix.driver_type }} / Scylla ${{ matrix.scylla_version }}` | `current-workflow` |
| Running | `datastax / Scylla LATEST / integration-test` | `current-workflow (datastax, datastax/java-driver, LATEST) / integration-test` |

Full running output after fix:
```
current-workflow (datastax, datastax/java-driver, LATEST) / integration-test
current-workflow (scylla, scylladb/java-driver, LATEST) / integration-test
current-workflow (scylla, scylladb/java-driver, PRIOR) / integration-test
current-workflow (scylla, scylladb/java-driver, LTS-LATEST) / integration-test
current-workflow (scylla, scylladb/java-driver, LTS-PRIOR) / integration-test
```

### `changed-driver-version-tests` (skipped when `version_count == 0`)

| State | Before | After |
|---|---|---|
| Skipped | `${{ matrix.driver_type }} ${{ matrix.driver_version }} / Scylla LATEST` | `changed-driver-version-tests` |
| Running | `datastax 4.19.2 / Scylla LATEST / integration-test` | TBD — observable in any PR touching `versions/` files |

> Note: `changed-driver-version-tests` is skipped in this PR (no `versions/` files changed), so the running format after the fix has not been captured yet. The skipped behavior is fully validated via PR #152.

## Fix

Remove the explicit `name` field from both jobs. GitHub falls back to the job ID as the base name:
- **When skipped:** displays the job ID — clean, no unevaluated template noise
- **When running:** auto-appends all matrix values per row for full disambiguation

## CI validation

### Scenario 1 — `current-workflow` running (this PR)

`pr-integration-tests.yml` is in `RUNNER_PATHS`, so changing it sets `runner_changed = true` — `current-workflow` runs with the full 5-job matrix. Skipped and running behavior for `current-workflow` both observable here.

### Scenario 2 — `current-workflow` skipped (PR #152, revertable)

PR #152 temporarily excludes `pr-integration-tests.yml` from `RUNNER_PATHS` to force `runner_changed = false`, causing `current-workflow` to be skipped. Captures the skipped display for both jobs.
