### PR TITLE
temp: simulate skipped current-workflow for PR #151 Scenario 2 (DO NOT MERGE)

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -91,7 +91,12 @@ jobs:
           echo "scripts/image was updated."
 
   current-workflow:
-    name: ${{ matrix.driver_type }} / Scylla ${{ matrix.scylla_version }}
+    # No explicit name: when this job is skipped (runner_changed == false), GitHub Actions
+    # collapses the entire matrix to a single UI entry and displays the job name with
+    # unevaluated template variables (e.g. "${{ matrix.driver_type }} / Scylla
+    # ${{ matrix.scylla_version }}"). With no name field, GitHub falls back to the job ID
+    # ("current-workflow") when skipped, and auto-appends matrix values per row when running:
+    # e.g. "current-workflow (datastax, LATEST) / integration-test".
     needs: changes
     if: ${{ needs.changes.outputs.runner_changed == 'true' }}
     strategy:

--- a/scripts/pr_integration_changes.py
+++ b/scripts/pr_integration_changes.py
@@ -14,7 +14,10 @@ IMAGE_SOURCE_PATHS = {"scripts/Dockerfile", "scripts/requirements.txt"}
 
 RUNNER_PATHS = {
     ".github/workflows/integration-tests.yml",
-    ".github/workflows/pr-integration-tests.yml",
+    # pr-integration-tests.yml intentionally excluded here to simulate runner_changed == false,
+    # forcing current-workflow to be skipped. This is a temporary revertable change to document
+    # the skipped-job UI behavior (Scenario 2 of PR #151 CI validation).
+    # ".github/workflows/pr-integration-tests.yml",
     "scripts/run_test.sh",
     "scripts/image",
     *IMAGE_SOURCE_PATHS,


### PR DESCRIPTION
## Purpose

This is a **temporary, revertable PR** created solely to document the skipped-job UI behavior for **Scenario 2** of PR #151.

By excluding `pr-integration-tests.yml` from `RUNNER_PATHS` in `pr_integration_changes.py`, `runner_changed` evaluates to `false` for this PR. This causes `current-workflow` to be **skipped**, allowing us to observe and document what the skipped-job name looks like with the fix from PR #151 applied.

**DO NOT MERGE.** This PR exists only to capture CI output.

## What to observe

With the fix from PR #151 in place and `current-workflow` skipped, the expected display is:

```
current-workflow
```

Instead of the previous broken display:

```
${{ matrix.driver_type }} / Scylla ${{ matrix.scylla_version }}
```

## Contains

- Fix from PR #151 (remove explicit `name` from `current-workflow`)
- Temporary exclusion of `pr-integration-tests.yml` from `RUNNER_PATHS` to force skip

## Related

- PR #151 — the actual fix being validated
