### PR TITLE
scylla/3.11.x: fix ShardAwarenessTest patches for Scylla 2025.1

### DIFF
--- a/versions/scylla/3.11.4.0/ignore.yaml
+++ b/versions/scylla/3.11.4.0/ignore.yaml
@@ -1,12 +1,14 @@
 tests:
   # test count on tracing which it's content is different in scylla, should be skipped on scylla
-  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+  # (should_create_tombstone_when_null_value_on_bound_statement)
+  - PreparedStatementTest
 
   # disable cause now CCM uses different ip address and port for the JMX
   - CCMBridgeTest
 
   # using 2 node cluster, and stopping one, isn't supported by scylla since raft
-  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+  # (should_receive_changes_made_while_control_connection_is_down_on_reconnect)
+  - SchemaChangesCCTest
 
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)

--- a/versions/scylla/3.11.4.0/patch
+++ b/versions/scylla/3.11.4.0/patch
@@ -759,15 +759,35 @@ index 777ea439f8..a63e169dac 100644
      assertThat(table.getColumns().get(1))
          .isNotNull()
 diff --git a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
-index b1867a0562..ac36feb518 100644
+index b1867a0562..8fa0a885b9 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
-@@ -95,7 +95,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
+@@ -82,12 +82,17 @@
+           event.getSource(),
+           event.getThreadName(),
+           event.getDescription());
+-      assertThat(event.getThreadName()).startsWith(shard);
++      // Only data-local events carry the owning shard. Scylla 2025.1 adds coordinator-side
++      // events that legitimately run on shard 0 regardless of the data shard. Also, since
++      // Scylla 2025.1 the thread name carries a service-level suffix ("shard N/sl:<level>"),
++      // so strip it before comparing.
+       if (event.getDescription().contains("querying locally")) {
+         anyLocal = true;
++        String normalized = event.getThreadName().replaceFirst("/sl:[^/]*$", "");
++        assertThat(normalized).startsWith(shard);
+       }
+     }
+-    assertThat(anyLocal);
++    assertTrue(anyLocal, "No 'querying locally' trace event was observed for the query");
+   }
+ 
+   @Test(groups = "short")
+@@ -95,7 +100,7 @@ public class ShardAwarenessTest extends CCMTestsSupport {
      session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
      session()
          .execute(
 -            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
-+            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
++            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'} AND TABLETS = {'enabled': false}");
      session()
          .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
  

--- a/versions/scylla/3.11.4.0/patch
+++ b/versions/scylla/3.11.4.0/patch
@@ -28,15 +28,16 @@ index 4c9ba61fc5..fa14e1a47a 100644
  
      String installDirectory = System.getProperty("cassandra.directory");
      String branch = System.getProperty("cassandra.branch");
-@@ -206,7 +207,10 @@ public class CCMBridge implements CCMAccess {
+@@ -206,7 +207,11 @@ public class CCMBridge implements CCMAccess {
        installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
      } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
        installArgs.add(" --scylla ");
 -      installArgs.add("-v release:" + inputScyllaVersion);
-+      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
-+      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
-+      // proven difficult.
-+      installArgs.add("-v " + inputScyllaVersion);
++      // Use release: prefix in GitHub Actions (no local tarball); bare version in Jenkins
++      // where SCYLLA_UNIFIED_PACKAGE points CCM to a local tarball via packages_from_env().
++      String scyllaCcmVersion = System.getenv("SCYLLA_UNIFIED_PACKAGE") != null
++          ? inputScyllaVersion : "release:" + inputScyllaVersion;
++      installArgs.add("-v " + scyllaCcmVersion);
  
        // Detect Scylla Enterprise - it should start with
        // a 4-digit year.

--- a/versions/scylla/3.11.5.15/ignore.yaml
+++ b/versions/scylla/3.11.5.15/ignore.yaml
@@ -1,12 +1,14 @@
 tests:
   # test count on tracing which its content is different in scylla, should be skipped on scylla
-  - PreparedStatementTest #should_create_tombstone_when_null_value_on_bound_statement
+  # (should_create_tombstone_when_null_value_on_bound_statement)
+  - PreparedStatementTest
 
   # disable because now CCM uses different ip address and port for the JMX
   - CCMBridgeTest
 
   # using 2 node cluster, and stopping one, isn't supported by scylla since raft
-  - SchemaChangesCCTest #should_receive_changes_made_while_control_connection_is_down_on_reconnect
+  # (should_receive_changes_made_while_control_connection_is_down_on_reconnect)
+  - SchemaChangesCCTest
 
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
@@ -17,4 +19,5 @@ tests:
 
   # node stop/start sequence causes Scylla to fail to open its binary port within the 5-minute
   # CCM timeout, likely due to timing differences vs Cassandra in this driver version
-  - NodeRefreshDebouncerTest #should_call_onAdd_with_bootstrap_stop_start
+  # (should_call_onAdd_with_bootstrap_stop_start)
+  - NodeRefreshDebouncerTest

--- a/versions/scylla/3.11.5.15/patch
+++ b/versions/scylla/3.11.5.15/patch
@@ -2,7 +2,7 @@ diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b
 index 344678c814..74a126cb20 100644
 --- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
 +++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
-@@ -207,11 +207,11 @@ public class CCMBridge implements CCMAccess {
+@@ -207,11 +207,12 @@ public class CCMBridge implements CCMAccess {
        installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
      } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
        installArgs.add(" --scylla ");
@@ -11,10 +11,11 @@ index 344678c814..74a126cb20 100644
 -      } else {
 -        installArgs.add("-v " + inputScyllaVersion);
 -      }
-+      // Dropping release prefix to force CCM to use version downloaded locally by Jenkins since
-+      // resolving proper CCM version argument value based on the Jenkins's scylla-version was
-+      // proven difficult.
-+      installArgs.add("-v " + inputScyllaVersion);
++      // Use release: prefix in GitHub Actions (no local tarball); bare version in Jenkins
++      // where SCYLLA_UNIFIED_PACKAGE points CCM to a local tarball via packages_from_env().
++      String scyllaCcmVersion = System.getenv("SCYLLA_UNIFIED_PACKAGE") != null
++          ? inputScyllaVersion : "release:" + inputScyllaVersion;
++      installArgs.add("-v " + scyllaCcmVersion);
 +
        // Detect Scylla Enterprise - it should start with
        // a 4-digit year.

--- a/versions/scylla/3.11.5.15/patch
+++ b/versions/scylla/3.11.5.15/patch
@@ -97,4 +97,36 @@ index ea75f84544..ea70e9081a 100644
  public class SessionStressTest extends CCMTestsSupport {
  
    private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
-
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+index ac36feb518..8fa0a885b9 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/ShardAwarenessTest.java
+@@ -82,12 +82,17 @@
+           event.getSource(),
+           event.getThreadName(),
+           event.getDescription());
+-      assertThat(event.getThreadName()).startsWith(shard);
++      // Only data-local events carry the owning shard. Scylla 2025.1 adds coordinator-side
++      // events that legitimately run on shard 0 regardless of the data shard. Also, since
++      // Scylla 2025.1 the thread name carries a service-level suffix ("shard N/sl:<level>"),
++      // so strip it before comparing.
+       if (event.getDescription().contains("querying locally")) {
+         anyLocal = true;
++        String normalized = event.getThreadName().replaceFirst("/sl:[^/]*$", "");
++        assertThat(normalized).startsWith(shard);
+       }
+     }
+-    assertThat(anyLocal);
++    assertTrue(anyLocal, "No 'querying locally' trace event was observed for the query");
+   }
+ 
+   @Test(groups = "short")
+@@ -95,7 +100,7 @@
+     session().execute("DROP KEYSPACE IF EXISTS shardawaretest");
+     session()
+         .execute(
+-            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}");
++            "CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'} AND TABLETS = {'enabled': false}");
+     session()
+         .execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+ 


### PR DESCRIPTION
## Problem

`ShardAwarenessTest.correctShardInTracingTest` fails on Scylla 2025.1 in the `scylla/3.11.4.0` and `scylla/3.11.5.15` matrix jobs with:

```
Expecting: <"shard 0/sl:default"> to start with: <"shard 1">
```

See companion driver PR for full root-cause analysis: https://github.com/scylladb/java-driver/pull/931

## Scope

This PR covers **3.x driver versions only** (`3.11.4.0`, `3.11.5.15`). The `4.x` scylla driver versions are **not changed** — `4.19.2.0` requires Java 11+ and cannot run in the current matrix infrastructure (which hardcodes Java 8 in `scripts/run_test.sh`). That is tracked separately in issue #170 / draft PR #171.

## Changes

### `versions/scylla/3.11.4.0/patch`

Replaces the existing 1-hunk `ShardAwarenessTest` diff with a 2-hunk diff (`b1867a0562→0d466c6b2a`) that:

1. **Hunk 1** (`@@ -82,12 +82,17 @@`): narrows assertion to `"querying locally"` events only, strips `/sl:...` suffix, and fixes the `assertThat(anyLocal)` no-op → `assertTrue(anyLocal)`.
2. **Hunk 2** (`@@ -95,7 +100,7 @@`): upgrades `SimpleStrategy` to `NetworkTopologyStrategy` **and** adds `AND TABLETS = {'enabled': false}` to disable tablets (line numbers shifted by +5 after hunk 1).

Also updates the `CCMBridge` `getScyllaVersion()` hunk to conditionally apply the `release:` prefix only when `SCYLLA_UNIFIED_PACKAGE` is not set (matching the pattern from PR #150).

### `versions/scylla/3.11.5.15/patch`

Adds a 2-hunk `ShardAwarenessTest` diff (`ac36feb518→0d466c6b2a`):

1. **Hunk 1** (`@@ -82,12 +82,17 @@`): same assertion fix as above.
2. **Hunk 2** (`@@ -95,7 +100,7 @@`): adds `AND TABLETS = {'enabled': false}` to the existing `NetworkTopologyStrategy` keyspace (NTS is already in the `3.11.5.15` tag).

Also includes the same conditional `release:` prefix fix for `CCMBridge`.

### `versions/scylla/3.11.4.0/ignore.yaml` and `versions/scylla/3.11.5.15/ignore.yaml`

Fix class-level ignore entries to use bare `- ClassName` format (without inline `#method` comments) to satisfy the PR #163 validator.

## Testing

### Primary goal — `scylla-2025.1`

[`java-driver-matrix-2025.1` build #2](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-2025.1/2/) — **GREEN** on Scylla `2025.1.15`, all tested driver versions. `correctShardInTracingTest` passes explicitly for both `3.11.4.0` and `3.11.5.15`.

### No regressions — master

[`java-driver-matrix-master` build #51](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/java-driver-matrix-master/51/) confirms:

| Driver version | Failures |
|---|---|
| `scylla/3.11.5.15` | 0 |
| `scylla/3.11.4.0` | 0 |
| `scylla/4.19.0.9` | 0 |
| `datastax/4.19.3` | 0 |
| `datastax/4.19.2` | 0 |

`correctShardInTracingTest` shows **SUCCESS** explicitly in the log for both `3.11.5.15` and `3.11.4.0`.

> Note: both staging builds show overall `FAILURE` in Jenkins due to the email-sender Docker container (`Docker exitcode: 1`) failing to deliver the result email — a known staging infrastructure issue unrelated to test results. All test summaries confirm `failures: 0`.
