### PR TITLE
fix: preserve junit diagnostics

### DIFF
--- a/processjunit.py
+++ b/processjunit.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from ast import literal_eval
 from functools import cached_property, lru_cache
 from pathlib import Path
@@ -30,18 +31,13 @@ class ProcessJUnit:
             if is_first_run:
                 is_first_run = False
                 properties_element = tree.find("properties")
-                new_properties_element = ElementTree.SubElement(
-                    new_tree, properties_element.tag, attrib=properties_element.attrib)
-                _ = [ElementTree.SubElement(new_properties_element, element.tag, attrib=element.attrib)
-                     for element in properties_element]
+                if properties_element is not None:
+                    new_tree.append(deepcopy(properties_element))
             for testcase_parent_element in tree.iterfind("testcase"):
-                attrib = testcase_parent_element.attrib
+                new_testcase_parent_element = deepcopy(testcase_parent_element)
+                attrib = new_testcase_parent_element.attrib
                 attrib['classname'] = f"{self.driver_type}.{self.tag}.{attrib['classname']}"
-                new_testcase_parent_element = ElementTree.SubElement(
-                    new_tree, testcase_parent_element.tag, attrib=testcase_parent_element.attrib)
-                _ = [ElementTree.SubElement(new_testcase_parent_element, testcase_child_element.tag,
-                                            attrib=testcase_child_element.attrib)
-                     for testcase_child_element in testcase_parent_element]
+                new_tree.append(new_testcase_parent_element)
 
         new_tree.attrib["name"] = self.report_path.stem
         new_tree.attrib.update({key: str(value) for key, value in self._summary.items()})
@@ -63,4 +59,3 @@ class ProcessJUnit:
     def clear_original_reports(self):
         logging.info("Removing all run's xml files of '%s' version", self.tag)
         shutil.rmtree(self.tests_result_path)
-

--- a/tests/test_processjunit.py
+++ b/tests/test_processjunit.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from xml.etree import ElementTree
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from processjunit import ProcessJUnit
+
+
+def test_create_report_preserves_testcase_diagnostics(tmp_path):
+    source_reports = tmp_path / "failsafe-reports"
+    source_reports.mkdir()
+    output_report = tmp_path / "reports" / "TEST-datastax-4.19.3.xml"
+
+    (source_reports / "TEST-com.example.DriverIT.xml").write_text(
+        """\
+<testsuite name="DriverIT" tests="2" errors="1" skipped="0" failures="1" time="1.500">
+  <properties>
+    <property name="it.test" value="DriverIT"/>
+  </properties>
+  <testcase classname="com.example.DriverIT" name="fails" time="0.100">
+    <failure message="boom" type="AssertionError">stack line 1
+stack line 2</failure>
+    <system-out>stdout details</system-out>
+  </testcase>
+  <testcase classname="com.example.DriverIT" name="errors" time="0.200">
+    <error message="bad" type="RuntimeError">error line 1
+error line 2</error>
+    <system-err>stderr details</system-err>
+  </testcase>
+</testsuite>
+""",
+        encoding="utf-8",
+    )
+
+    report = ProcessJUnit(
+        new_report_xml_path=output_report,
+        tests_result_path=source_reports,
+        tag="4.19.3",
+        driver_type="datastax",
+    )
+
+    assert report.summary == {"time": 1.5, "tests": 2, "errors": 1, "skipped": 0, "failures": 1}
+
+    root = ElementTree.parse(output_report).getroot()
+    assert root.find("./properties/property").attrib == {"name": "it.test", "value": "DriverIT"}
+    testcases = root.findall("./testcase")
+    assert testcases[0].attrib["classname"] == "datastax.4.19.3.com.example.DriverIT"
+    assert testcases[0].find("failure").text == "stack line 1\nstack line 2"
+    assert testcases[0].find("system-out").text == "stdout details"
+    assert testcases[1].find("error").text == "error line 1\nerror line 2"
+    assert testcases[1].find("system-err").text == "stderr details"


### PR DESCRIPTION
## Summary

- Deep-copy merged JUnit `properties` and `testcase` elements so failure/error text and test output survive report aggregation.
- Add regression coverage for merged failure, error, `system-out`, and `system-err` content.

Closes #156.

## Testing

- `pytest -q`