### PR TITLE
ci: trigger master integration workflow

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -91,6 +91,7 @@ jobs:
           echo "scripts/image was updated."
 
   current-workflow:
+    # Comment-only trigger point for temporary PRs that need to exercise the full runner matrix.
     # No explicit name: when this job is skipped (runner_changed == false), GitHub Actions
     # collapses the entire matrix to a single UI entry and displays the job name with
     # unevaluated template variables (e.g. "${{ matrix.driver_type }} / Scylla


### PR DESCRIPTION
## Summary

This is a temporary PR to exercise the PR integration workflow against the current `master` branch.

It intentionally touches `.github/workflows/pr-integration-tests.yml` with a comment-only change so the change detector marks `runner_changed=true` and runs the full runner matrix.

## Testing

- `pytest -q`