### PR TITLE
ci: trigger final master integration check

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -92,7 +92,6 @@ jobs:
 
   current-workflow:
     # Comment-only trigger point for temporary PRs that need to exercise the full runner matrix.
-    # Trigger marker: final master integration check after issue-fix PRs.
     # No explicit name: when this job is skipped (runner_changed == false), GitHub Actions
     # collapses the entire matrix to a single UI entry and displays the job name with
     # unevaluated template variables (e.g. "${{ matrix.driver_type }} / Scylla

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -92,6 +92,7 @@ jobs:
 
   current-workflow:
     # Comment-only trigger point for temporary PRs that need to exercise the full runner matrix.
+    # Trigger marker: final master integration check after issue-fix PRs.
     # No explicit name: when this job is skipped (runner_changed == false), GitHub Actions
     # collapses the entire matrix to a single UI entry and displays the job name with
     # unevaluated template variables (e.g. "${{ matrix.driver_type }} / Scylla

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+# CI trigger marker: final master integration check after issue-fix PRs.
+
 help_text="
 $(basename $0) - Run java-driver integration tests over scylla using docker
 


### PR DESCRIPTION
Run the full PR integration matrix against current master after the issue-fix PRs have landed.\n\nThis intentionally changes only a comment in scripts/run_test.sh, which is one of the existing runner-change paths, so PR change detection executes the full current-workflow matrix without requiring a workflow-file change.