### PR TITLE
scylla/4.19.2.0: add version directory (Part A of #170)

### DIFF
--- a/versions/scylla/4.19.2.0/ignore.yaml
+++ b/versions/scylla/4.19.2.0/ignore.yaml
@@ -1,0 +1,6 @@
+tests:
+  # awaitScyllaAuth times out waiting for Scylla auth to become available (30s exceeded)
+  - PlainTextAuthProviderIT
+  # ccm start fails intermittently when starting clusters inside test methods
+  # (both TLS and non-TLS variants); ignore the whole class to avoid flakiness
+  - ClientRoutesIT

--- a/versions/scylla/4.19.2.0/patch
+++ b/versions/scylla/4.19.2.0/patch
@@ -1,0 +1,359 @@
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
+index d70c6d3fac..c9839c3b93 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PeersV2NodeRefreshIT.java
+@@ -29,6 +29,7 @@ import com.datastax.oss.simulacron.common.cluster.QueryLog;
+ import com.datastax.oss.simulacron.server.BoundCluster;
+ import com.datastax.oss.simulacron.server.Server;
+ import java.util.concurrent.ExecutionException;
++import org.junit.After;
+ import org.junit.AfterClass;
+ import org.junit.BeforeClass;
+ import org.junit.Test;
+@@ -38,6 +39,7 @@ public class PeersV2NodeRefreshIT {
+ 
+   private static Server peersV2Server;
+   private static BoundCluster cluster;
++  private static CqlSession session;
+ 
+   @BeforeClass
+   public static void setup() {
+@@ -55,6 +57,13 @@ public class PeersV2NodeRefreshIT {
+     }
+   }
+ 
++  @After
++  public void closeSession() {
++    if (session != null) {
++      session.close();
++    }
++  }
++
+   @Test
+   public void should_successfully_send_peers_v2_node_refresh_query()
+       throws InterruptedException, ExecutionException {
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
+index 9a23f36854..872f1221d7 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/clientroutes/ClientRoutesIT.java
+@@ -91,6 +91,13 @@ public class ClientRoutesIT {
+   private static final Logger LOG = LoggerFactory.getLogger(ClientRoutesIT.class);
+ 
+   private static final int NLB_BASE_PORT = 29042;
++  // Separate base port for should_work_with_mixed_proxy_and_direct_nodes to avoid port collision
++  // with should_survive_full_node_replacement_through_nlb, which also uses NLB_BASE_PORT.
++  // Both tests run sequentially with no delay between them; using distinct ranges eliminates the
++  // risk of SO_REUSEADDR being insufficient to rebind ports still in TIME_WAIT.
++  //   NLB_BASE_PORT  range: 29042 (discovery), 29043-29046 (nodes 1-4)
++  //   NLB_BASE_PORT_2 range: 29100 (discovery), 29101 (node 1)
++  private static final int NLB_BASE_PORT_2 = 29100;
+   private static final String NLB_ADDRESS = "127.254.254.254";
+   private static final String CONNECTION_ID = "11111111-1111-1111-1111-111111111111";
+   private static final String DC_NAME = "dc1";
+@@ -829,7 +836,7 @@ public class ClientRoutesIT {
+       ccm.create();
+       ccm.start();
+ 
+-      NlbSimulator nlb = new NlbSimulator(ccm, NLB_ADDRESS, NLB_BASE_PORT);
++      NlbSimulator nlb = new NlbSimulator(ccm, NLB_ADDRESS, NLB_BASE_PORT_2);
+       try {
+         nlb.addNode(1);
+ 
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+index aeda4a02c7..782aa2dfdb 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/pool/AdvancedShardAwarenessIT.java
+@@ -234,7 +234,7 @@ public class AdvancedShardAwarenessIT {
+         CqlSession session4 = CompletableFutures.getUninterruptibly(stage4); ) {
+       List<CqlSession> allSessions = Arrays.asList(session1, session2, session3, session4);
+       Awaitility.await()
+-          .atMost(20, TimeUnit.SECONDS)
++          .atMost(60, TimeUnit.SECONDS)
+           .pollInterval(500, TimeUnit.MILLISECONDS)
+           .until(() -> areAllPoolsFullyInitialized(allSessions, expectedChannelsPerNode));
+       int tolerance = 2; // Sometimes socket ends up already in use
+diff --git a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+index 0498462ce1..d99e0d3f68 100644
+--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
++++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/resolver/MockResolverIT.java
+@@ -274,8 +274,10 @@ public class MockResolverIT {
+     int counter = 0;
+     while (filteredNodes.size() == 1) {
+       counter++;
+-      if (counter == 255) {
+-        LOG.error("Completed 254 runs. Breaking.");
++      // Capping to 99 in the patch because that's what ccm create --help says is the max id
++      // allowed
++      if (counter == 99) {
++        LOG.error("Completed 99 runs. Breaking.");
+         break;
+       }
+       LOG.warn(
+diff --git a/pom.xml b/pom.xml
+index 96fb2401c4..2e491fbafa 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -100,7 +100,7 @@
+     <skipUnitTests>${skipTests}</skipUnitTests>
+     <release.autopublish>false</release.autopublish>
+     <pushChanges>false</pushChanges>
+-    <mockitoopens.argline />
++    <mockitoopens.argline/>
+     <api.plumber.skip>false</api.plumber.skip>
+   </properties>
+   <dependencyManagement>
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+index b50d56823b..eb12ba2c7c 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+@@ -23,9 +23,14 @@
+  */
+ package com.datastax.oss.driver.api.testinfra.ccm;
+ 
++import static org.awaitility.Awaitility.await;
++
++import com.datastax.oss.driver.api.core.AllNodesFailedException;
++import com.datastax.oss.driver.api.core.CqlSession;
+ import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+ import com.datastax.oss.driver.api.core.ProtocolVersion;
+ import com.datastax.oss.driver.api.core.Version;
++import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider;
+ import com.datastax.oss.driver.api.core.metadata.EndPoint;
+ import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
+ import com.datastax.oss.driver.api.testinfra.ScyllaOnly;
+@@ -36,12 +41,17 @@ import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+ import java.net.InetSocketAddress;
+ import java.util.Collections;
+ import java.util.Set;
++import java.util.concurrent.TimeUnit;
+ import org.junit.AssumptionViolatedException;
+ import org.junit.runner.Description;
+ import org.junit.runners.model.Statement;
++import org.slf4j.Logger;
++import org.slf4j.LoggerFactory;
+ 
+ public abstract class BaseCcmRule extends CassandraResourceRule {
+ 
++  private static final Logger LOG = LoggerFactory.getLogger(BaseCcmRule.class);
++
+   protected final CcmBridge ccmBridge;
+ 
+   BaseCcmRule(CcmBridge ccmBridge) {
+@@ -62,6 +72,37 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
+   protected void before() {
+     ccmBridge.create();
+     ccmBridge.start();
++    if (CcmBridge.isDistributionOf(BackendType.SCYLLA) && ccmBridge.isAuthEnabled()) {
++      awaitScyllaAuth();
++    }
++  }
++
++  private void awaitScyllaAuth() {
++    InetSocketAddress contact = new InetSocketAddress(ccmBridge.getNodeIpAddress(1), 9042);
++    LOG.info("Waiting for ScyllaDB superuser to become available at {}", contact);
++    await()
++        .atMost(30, TimeUnit.SECONDS)
++        .pollInterval(1, TimeUnit.SECONDS)
++        .until(
++            () -> {
++              try (CqlSession session =
++                  CqlSession.builder()
++                      .addContactPoint(contact)
++                      .withLocalDatacenter("dc1")
++                      .withAuthProvider(
++                          new ProgrammaticPlainTextAuthProvider("cassandra", "cassandra"))
++                      .build()) {
++                return session.execute("SELECT key FROM system.local WHERE key='local'").one()
++                    != null;
++              } catch (AllNodesFailedException e) {
++                LOG.debug("ScyllaDB superuser not ready yet: {}", e.getMessage());
++                return false;
++              } catch (Exception e) {
++                LOG.debug("ScyllaDB auth check failed unexpectedly: {}", e.getMessage());
++                return false;
++              }
++            });
++    LOG.info("ScyllaDB superuser is ready");
+   }
+ 
+   @Override
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+index e7b2b4e4a0..8fbbed8d95 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+@@ -185,6 +185,7 @@ public class CcmBridge implements AutoCloseable {
+   private final List<String> createOptions;
+   private final List<String> dseWorkloads;
+   private final String jvmArgs;
++  private final boolean authEnabled;
+ 
+   private CcmBridge(
+       Path configDirectory,
+@@ -195,7 +196,8 @@ public class CcmBridge implements AutoCloseable {
+       List<String> dseConfigurationRawYaml,
+       List<String> createOptions,
+       Collection<String> jvmArgs,
+-      List<String> dseWorkloads) {
++      List<String> dseWorkloads,
++      boolean authEnabled) {
+     this.configDirectory = configDirectory;
+     if (nodes.length == 1) {
+       // Hack to ensure that the default DC is always called 'dc1': pass a list ('-nX:0') even if
+@@ -237,6 +239,7 @@ public class CcmBridge implements AutoCloseable {
+     }
+     this.jvmArgs = allJvmArgs.toString();
+     this.dseWorkloads = dseWorkloads;
++    this.authEnabled = authEnabled;
+   }
+ 
+   // Copied from Netty's PlatformDependent to avoid the dependency on Netty
+@@ -343,7 +346,15 @@
+       if (shouldReplace) {
+         versionString = versionString.replace(".0-", ".");
+       }
+-      return "release:" + versionString;
++      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
++      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
++      // bare version string so CCM resolves via packages_from_env() and uses the local file.
++      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
++      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
++        return versionString;
++      }
++      return "release:" + versionString;
+     }
+     // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
+     // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when
+@@ -503,7 +508,18 @@ public class CcmBridge implements AutoCloseable {
+   }
+ 
+   public void addWithoutStart(int n, String dc) {
+-    String[] initialArgs = new String[] {"add", "-i", ipPrefix + n, "-d", dc, "node" + n};
++    // Pass the JMX port explicitly so CCM cannot auto-assign a port that collides with
++    // another node that was added in the same test run.  CCM's auto-assign formula is
++    // 7000 + nodeid * 100 + cluster.id, where cluster.id is always 0 for CCM clusters
++    // created by CcmBridge (they are created fresh in a temp config directory).  Using
++    // the same formula here ensures the port is predictable and avoids the "JMX port is
++    // already in use" error that occurs when CCM resolves the nodeid from the current
++    // nodelist length rather than from the requested node number.
++    int jmxPort = 7000 + n * 100;
++    String[] initialArgs =
++        new String[] {
++          "add", "-i", ipPrefix + n, "-j", String.valueOf(jmxPort), "-d", dc, "node" + n
++        };
+     ArrayList<String> args = new ArrayList<>(Arrays.asList(initialArgs));
+     args.addAll(Arrays.asList(DISTRIBUTION.getCcmOptions()));
+     execute(args.toArray(new String[] {}));
+@@ -643,6 +660,15 @@ public class CcmBridge implements AutoCloseable {
+     return ipPrefix + nodeId;
+   }
+ 
++  /**
++   * Returns {@code true} if a non-AllowAll authenticator was configured for this cluster. Used by
++   * {@link BaseCcmRule} to determine whether a post-start auth readiness wait is needed on
++   * ScyllaDB, which provisions the default superuser asynchronously.
++   */
++  boolean isAuthEnabled() {
++    return authEnabled;
++  }
++
+   private static final String IN_MS_STR = "_in_ms";
+   private static final int IN_MS_STR_LENGTH = IN_MS_STR.length();
+   private static final String ENABLE_STR = "enable_";
+@@ -690,6 +716,7 @@ public class CcmBridge implements AutoCloseable {
+     private String ipPrefix;
+     private final List<String> createOptions = new ArrayList<>();
+     private final List<String> dseWorkloads = new ArrayList<>();
++    private boolean authEnabled = false;
+ 
+     private final Path configDirectory;
+ 
+@@ -708,6 +735,9 @@ public class CcmBridge implements AutoCloseable {
+ 
+     public Builder withCassandraConfiguration(String key, Object value) {
+       cassandraConfiguration.put(key, value);
++      if ("authenticator".equals(key) && !"AllowAllAuthenticator".equals(value)) {
++        authEnabled = true;
++      }
+       return this;
+     }
+ 
+@@ -736,6 +766,12 @@ public class CcmBridge implements AutoCloseable {
+       return this;
+     }
+ 
++    /** Sets a numeric cluster ID prefix used by {@link CustomCcmRule} to avoid IP collisions. */
++    public Builder withIdPrefix(String idPrefix) {
++      this.ipPrefix = "127.0." + idPrefix + ".";
++      return this;
++    }
++
+     /** Adds an option to the {@code ccm create} command. */
+     public Builder withCreateOption(String option) {
+       this.createOptions.add(option);
+@@ -807,7 +843,8 @@ public class CcmBridge implements AutoCloseable {
+           dseRawYaml,
+           createOptions,
+           jvmArgs,
+-          dseWorkloads);
++          dseWorkloads,
++          authEnabled);
+     }
+   }
+ 
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+index 5ea1bf7ed3..3f7f5be283 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+@@ -17,6 +17,7 @@
+  */
+ package com.datastax.oss.driver.api.testinfra.ccm;
+ 
++import java.util.concurrent.atomic.AtomicInteger;
+ import java.util.concurrent.atomic.AtomicReference;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
+ public class CustomCcmRule extends BaseCcmRule {
+ 
+   private static final Logger LOG = LoggerFactory.getLogger(CustomCcmRule.class);
++  private static final AtomicInteger CLUSTER_ID = new AtomicInteger(1);
+   private static final AtomicReference<CustomCcmRule> CURRENT = new AtomicReference<>();
+ 
+   CustomCcmRule(CcmBridge ccmBridge) {
+@@ -84,6 +86,10 @@ public class CustomCcmRule extends BaseCcmRule {
+ 
+     private final CcmBridge.Builder bridgeBuilder = CcmBridge.builder();
+ 
++    public Builder() {
++      this.withIdPrefix(Integer.toString(CLUSTER_ID.incrementAndGet()));
++    }
++
+     public Builder withNodes(int... nodes) {
+       bridgeBuilder.withNodes(nodes);
+       return this;
+@@ -134,6 +140,11 @@ public class CustomCcmRule extends BaseCcmRule {
+       return this;
+     }
+ 
++    public Builder withIdPrefix(String idPrefix) {
++      bridgeBuilder.withIdPrefix(idPrefix);
++      return this;
++    }
++
+     public CustomCcmRule build() {
+       return new CustomCcmRule(bridgeBuilder.build());
+     }
+diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+index 7536c0ffdc..6e13cc5cf5 100644
+--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
++++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+@@ -198,7 +198,7 @@ public class SessionUtils {
+     SimpleStatement createKeyspace =
+         SimpleStatement.builder(
+                 String.format(
+-                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
++                    "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 } AND tablets = {'enabled': false};",
+                     keyspace.asCql(false)))
+             .setExecutionProfile(profile)
+             .build();


### PR DESCRIPTION
Closes #170 (together with Part B — `run_test.sh` Java 11 support).

## What this PR does (Part A)

Adds `versions/scylla/4.19.2.0/{patch,ignore.yaml}` based on `4.19.0.9/`, with one update:

**`pom.xml` hunk** — `4.19.2.0` added a new `<api.plumber.skip>false</api.plumber.skip>` property between `<mockitoopens.argline/>` and `</properties>`. The `4.19.0.9` patch fails to apply on `4.19.2.0` at this hunk. The updated hunk accounts for the new property.

All other hunks (`MockResolverIT`, `CcmBridge`, `BaseCcmRule`, `CustomCcmRule`, `SessionUtils`, etc.) carry over unchanged and apply with minor offsets.

## What is still needed (Part B)

`4.19.2.0` dropped Java 8 support:

- `maven-compiler-plugin` now sets `<release>11</release>`.
- `.mvn/jvm.config` was added with `--add-exports=jdk.compiler/...=ALL-UNNAMED` flags that Maven reads on startup — Java 8 rejects these and crashes before any plugin runs.

`scripts/run_test.sh` currently hardcodes `JAVA_HOME='/usr/lib/jvm/temurin-8-jdk-amd64/'` for every version. Part B must update this (conditionally or globally) to use Java 11 for `4.x` scylla driver versions, and ensure the Docker image used by the matrix has a Java 11 JDK installed.

## Status

- [x] `versions/scylla/4.19.2.0/patch` — complete, applies cleanly to the `4.19.2.0` tag
- [x] `versions/scylla/4.19.2.0/ignore.yaml` — complete (copy of `4.19.0.9/ignore.yaml`)
- [ ] `scripts/run_test.sh` — Java 11 support (Part B, separate commit/PR or added here)
- [ ] Docker image — confirm Java 11 JDK is installed

Not ready to merge until Part B is complete.
