### PR TITLE
ci: keep scylla patch compatible with latest driver

### DIFF
--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -89,19 +89,6 @@ index 0498462ce1..d99e0d3f68 100644
          break;
        }
        LOG.warn(
-diff --git a/pom.xml b/pom.xml
-index 96fb2401c4..2e491fbafa 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -100,7 +100,7 @@
-     <skipUnitTests>${skipTests}</skipUnitTests>
-     <release.autopublish>false</release.autopublish>
-     <pushChanges>false</pushChanges>
--    <mockitoopens.argline />
-+    <mockitoopens.argline/>
-   </properties>
-   <dependencyManagement>
-     <dependencies>
 diff --git a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
 index b50d56823b..eb12ba2c7c 100644
 --- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java


### PR DESCRIPTION
Extracted from #168 so the empty 3.x selector coverage stays separate from Scylla patch maintenance.\n\nThis removes a stale formatting-only pom.xml hunk from versions/scylla/4.19.0.9/patch that no longer applies cleanly with the latest driver sources.\n\nTests:\n- python3 -m pytest