### PR TITLE
ci: honor releng checkout parameters

### DIFF
--- a/scripts/jenkins-pipelines/java-driver-matrix-test.jenkinsfile
+++ b/scripts/jenkins-pipelines/java-driver-matrix-test.jenkinsfile
@@ -102,11 +102,13 @@ pipeline {
                     scyllaJavaDriverMatrixBranch = params.JAVA_DRIVER_MATRIX_BRANCH ?: branchProperties.stableDriverMatrixBranchName
                     apacheJavaDriverRepo = params.APACHE_JAVA_DRIVER_REPO ?: "https://github.com/apache/cassandra-java-driver.git"
                     scyllaJavaDriverRepo = params.SCYLLA_JAVA_DRIVER_REPO ?: "https://github.com/scylladb/java-driver.git"
+                    relengRepo = params.RELENG_REPO ?: gitProperties.scyllaPkgRepoUrl
+                    relengBranch = params.RELENG_BRANCH ?: branchProperties.stableBranchName
 
                     git.cleanWorkSpaceUponRequest()
                     git.checkoutToDir (javaDriverMatrixRepoUrl, scyllaJavaDriverMatrixBranch, gitProperties.scyllaJavaDriverMatrixCheckoutDir)
                     git.checkoutToDir (gitProperties.scyllaCcmRepoUrl, ccmBranch, gitProperties.scyllaCcmCheckoutDir)
-                    git.checkoutToDir (gitProperties.scyllaPkgRepoUrl, branchProperties.stableBranchName, gitProperties.scyllaPkgCheckoutDir)
+                    git.checkoutToDir (relengRepo, relengBranch, gitProperties.scyllaPkgCheckoutDir)
                     git.checkoutToDir (apacheJavaDriverRepo, "4.x", apacheJavaDriverCheckoutDir)
                     git.checkoutToDir (scyllaJavaDriverRepo, "3.x", scyllaJavaDriverCheckoutDir)
 


### PR DESCRIPTION
## Summary

- Use `RELENG_REPO` to override the default `scylla-pkg` repository during Jenkins checkout.
- Use `RELENG_BRANCH` to override the default `scylla-pkg` branch during Jenkins checkout.
- Preserve the existing defaults when both parameters are empty.

Fixes #102.

## Testing

- Ran `git diff --check`.
- Verified the change statically in `scripts/jenkins-pipelines/java-driver-matrix-test.jenkinsfile`.

## Issue location

The broken checkout logic is in this repository's Jenkinsfile, so the issue should remain in `scylladb/scylla-java-driver-matrix`; moving it to `scylla-pkg` is not needed.