### PR TITLE
ci: run isolated 3.x driver tests

### DIFF
--- a/run.py
+++ b/run.py
@@ -223,6 +223,19 @@ class Run:
             cmd.append(f"-Dit.test={tests_string}")
         return cmd
 
+    def _isolated_test_command(self, tests_string: str) -> List[str]:
+        cmd = self._mvn_command("-pl", "driver-core", "-Pisolated")
+        if tests_string:
+            cmd.append(f"-Dtest={tests_string}")
+        cmd.append("test")
+        return cmd
+
+    def _test_commands(self, tests_string: str) -> List[List[str]]:
+        commands = [self._test_command(tests_string)]
+        if self._tag.startswith('3'):
+            commands.append(self._isolated_test_command(tests_string))
+        return commands
+
     def _scylla_version_for_test_command(self) -> str:
         if (
                 self._driver_type == "apache"
@@ -267,31 +280,37 @@ class Run:
         logging.info("Starting build the version")
         self._run_command(self._mvn_command("install", "-DskipTests=true", "-Dmaven.javadoc.skip=true", "-V"))
 
-        cmd = self._test_command(tests_string)
+        test_commands = self._test_commands(tests_string)
 
         shutil.rmtree(self._report_path, ignore_errors=True)
         if self._scylla_version:
             scylla_version = self._scylla_version_for_test_command()
-            if self._tag.startswith('3') or self._driver_type != 'scylla':
-                cmd.append(f"-Dscylla.version={scylla_version}")
-            else:
-                # Way it works after 4.19.0.0 `ccm.distribution` was introduced
-                cmd.extend([f"-Dccm.version={scylla_version}", "-Dccm.distribution=scylla"])
-                # Before 4.19.0.0 it required a flag:
-                cmd.append("-Dccm.scylla")
+            for cmd in test_commands:
+                if self._tag.startswith('3') or self._driver_type != 'scylla':
+                    cmd.append(f"-Dscylla.version={scylla_version}")
+                else:
+                    # Way it works after 4.19.0.0 `ccm.distribution` was introduced
+                    cmd.extend([f"-Dccm.version={scylla_version}", "-Dccm.distribution=scylla"])
+                    # Before 4.19.0.0 it required a flag:
+                    cmd.append("-Dccm.scylla")
 
         elif self._scylla_install_dir:
-            cmd.append(f"-Dccm.directory={self._scylla_install_dir}")
+            for cmd in test_commands:
+                cmd.append(f"-Dccm.directory={self._scylla_install_dir}")
         else:
             raise ValueError("No scylla version or Cassandra dir defined")
 
         logging.info("Starting run the tests")
-        try:
-            self._run_command(cmd)
+        all_tests_passed = True
+        for cmd in test_commands:
+            try:
+                self._run_command(cmd)
+            except AssertionError:
+                # Some tests are failed
+                all_tests_passed = False
+
+        if all_tests_passed:
             logging.info("All tests are passed for '%s' version", self._tag)
-        except AssertionError:
-            # Some tests are failed
-            pass
         metadata_file = Path(os.path.dirname(__file__)) / "reports" / self.metadata_file_name
         metadata_file.parent.mkdir(exist_ok=True)
         metadata = {

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -38,6 +38,44 @@ def test_3x_test_command_defaults_empty_selector_to_all_tests(tmp_path):
     ]
 
 
+def test_3x_test_commands_include_isolated_profile_run(tmp_path):
+    runner = make_runner(tmp_path, tag="3.11.5.12")
+
+    assert runner._test_commands("") == [
+        [
+            "mvn",
+            "-B",
+            "-pl",
+            "driver-core",
+            "-Dtest.groups=short,long",
+            "-Dtest=*",
+            "test",
+        ],
+        [
+            "mvn",
+            "-B",
+            "-pl",
+            "driver-core",
+            "-Pisolated",
+            "test",
+        ],
+    ]
+
+
+def test_3x_isolated_test_command_keeps_explicit_selector(tmp_path):
+    runner = make_runner(tmp_path, tag="3.11.5.12")
+
+    assert runner._isolated_test_command("ControlConnectionTest") == [
+        "mvn",
+        "-B",
+        "-pl",
+        "driver-core",
+        "-Pisolated",
+        "-Dtest=ControlConnectionTest",
+        "test",
+    ]
+
+
 def test_3x_run_uses_all_tests_selector_when_no_tests_or_ignores(monkeypatch, tmp_path):
     runner = make_runner(tmp_path, tag="3.11.5.12")
     commands = []
@@ -49,13 +87,52 @@ def test_3x_run_uses_all_tests_selector_when_no_tests_or_ignores(monkeypatch, tm
 
     runner.run()
 
+    assert commands[-2:] == [
+        [
+            "mvn",
+            "-B",
+            "-pl",
+            "driver-core",
+            "-Dtest.groups=short,long",
+            "-Dtest=*",
+            "test",
+            "-Dscylla.version=2026.1.3",
+        ],
+        [
+            "mvn",
+            "-B",
+            "-pl",
+            "driver-core",
+            "-Pisolated",
+            "test",
+            "-Dscylla.version=2026.1.3",
+        ],
+    ]
+
+
+def test_3x_run_still_executes_isolated_tests_after_regular_test_failure(monkeypatch, tmp_path):
+    runner = make_runner(tmp_path, tag="3.11.5.12")
+    commands = []
+    runner.__dict__["ignore_tests"] = set()
+
+    def fake_run_command(cmd):
+        cmd = [str(arg) for arg in cmd]
+        commands.append(cmd)
+        if "-Dtest.groups=short,long" in cmd:
+            raise AssertionError("regular tests failed")
+
+    monkeypatch.setattr(run_module, "__file__", str(tmp_path / "run.py"))
+    monkeypatch.setattr(runner, "_apply_patch_files", lambda: None)
+    monkeypatch.setattr(runner, "_run_command", fake_run_command)
+
+    runner.run()
+
     assert commands[-1] == [
         "mvn",
         "-B",
         "-pl",
         "driver-core",
-        "-Dtest.groups=short,long",
-        "-Dtest=*",
+        "-Pisolated",
         "test",
         "-Dscylla.version=2026.1.3",
     ]


### PR DESCRIPTION
## Summary

- add a separate 3.x Maven test command that activates the existing `isolated` profile
- apply the same Scylla version/install parameters to every generated test command
- keep running the isolated 3.x command even if the short/long test command reports failures, so both report sets can be collected

Fixes #113

## Testing

- `pytest tests/test_run_command.py`
- `pytest`