### PR TITLE
ci: avoid release prefix for dev Scylla versions

### DIFF
--- a/run.py
+++ b/run.py
@@ -25,6 +25,10 @@ def strtobool(value: str) -> bool:
     raise ValueError(f"invalid truth value {value!r}")
 
 
+def is_scylla_release_repository_version(value: str) -> bool:
+    return re.fullmatch(r"\d+(?:\.\d+)+(?:[-.]?(?:rc|alpha|beta)\d+)?", value) is not None
+
+
 DEV_MODE = bool(strtobool(os.environ.get("DEV_MODE", "False")))
 
 
@@ -242,6 +246,7 @@ class Run:
                 and not self._tag.startswith("3")
                 and self._scylla_version
                 and ":" not in self._scylla_version
+                and is_scylla_release_repository_version(self._scylla_version)
                 and os.environ.get("SCYLLA_UNIFIED_PACKAGE") is None
         ):
             return f"release:{self._scylla_version}"

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -159,6 +159,30 @@ def test_apache_scylla_version_uses_release_prefix_for_ccm_download(monkeypatch,
     assert runner._scylla_version_for_test_command() == "release:2026.1.3"
 
 
+def test_apache_scylla_version_uses_release_prefix_for_rc_ccm_download(monkeypatch, tmp_path):
+    monkeypatch.delenv("SCYLLA_UNIFIED_PACKAGE", raising=False)
+    runner = make_runner(tmp_path, tag="4.12.0", driver_type="apache")
+    runner._scylla_version = "2026.1.0-rc1"
+
+    assert runner._scylla_version_for_test_command() == "release:2026.1.0-rc1"
+
+
+def test_apache_scylla_version_preserves_dev_version(monkeypatch, tmp_path):
+    monkeypatch.delenv("SCYLLA_UNIFIED_PACKAGE", raising=False)
+    runner = make_runner(tmp_path, tag="4.12.0", driver_type="apache")
+    runner._scylla_version = "2026.2.0~dev"
+
+    assert runner._scylla_version_for_test_command() == "2026.2.0~dev"
+
+
+def test_apache_scylla_version_preserves_hyphenated_dev_version(monkeypatch, tmp_path):
+    monkeypatch.delenv("SCYLLA_UNIFIED_PACKAGE", raising=False)
+    runner = make_runner(tmp_path, tag="4.12.0", driver_type="apache")
+    runner._scylla_version = "2026.2.0-dev"
+
+    assert runner._scylla_version_for_test_command() == "2026.2.0-dev"
+
+
 def test_apache_scylla_version_preserves_local_package_version(monkeypatch, tmp_path):
     monkeypatch.setenv("SCYLLA_UNIFIED_PACKAGE", "/tmp/scylla-unified.tar.gz")
     runner = make_runner(tmp_path, tag="4.12.0", driver_type="apache")

--- a/versions/apache/4.19.2/patch
+++ b/versions/apache/4.19.2/patch
@@ -927,8 +927,8 @@ index f0ce6bc5b..e76d46b11 100644
 +  // When SCYLLA_UNIFIED_PACKAGE is set, a local tarball is available (e.g. Jenkins
 +  // pre-downloads dev/unreleased builds not published to S3). Passing a bare version
 +  // causes CCM to use that local file via packages_from_env().
-+  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" so
-+  // CCM downloads the published release from S3.
++  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" only
++  // for release-repository version strings so CCM downloads them from S3.
 +  // This avoids "release:<dev-version>" S3 lookup failures on Jenkins while still
 +  // allowing GH Actions to download released versions automatically.
 +  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
@@ -942,11 +942,11 @@ index f0ce6bc5b..e76d46b11 100644
 +      // Already has a CCM prefix (e.g. "unstable/master:date") — pass through as-is.
 +      return SCYLLA_VERSION;
 +    }
-+    // Use local tarball when available, otherwise download from S3.
++    // Use local tarball when available; otherwise only release-repository versions use S3.
 +    if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
 +      return SCYLLA_VERSION;
 +    }
-+    return "release:" + SCYLLA_VERSION;
++    return SCYLLA_VERSION.matches("\\d+(\\.\\d+)+([-.]?(rc|alpha|beta)\\d+)?") ? "release:" + SCYLLA_VERSION : SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {
@@ -1126,4 +1126,3 @@ index 7536c0ffd..6e13cc5cf 100644
                      keyspace.asCql(false)))
              .setExecutionProfile(profile)
              .build();
-

--- a/versions/apache/4.19.3/patch
+++ b/versions/apache/4.19.3/patch
@@ -927,8 +927,8 @@ index f0ce6bc..e76d46b 100644
 +  // When SCYLLA_UNIFIED_PACKAGE is set, a local tarball is available (e.g. Jenkins
 +  // pre-downloads dev/unreleased builds not published to S3). Passing a bare version
 +  // causes CCM to use that local file via packages_from_env().
-+  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" so
-+  // CCM downloads the published release from S3.
++  // When SCYLLA_UNIFIED_PACKAGE is not set (e.g. GH Actions CI), prepend "release:" only
++  // for release-repository version strings so CCM downloads them from S3.
 +  // This avoids "release:<dev-version>" S3 lookup failures on Jenkins while still
 +  // allowing GH Actions to download released versions automatically.
 +  // Regression introduced by PR #147 (commit 3107868) which added getScyllaCcmVersionString()
@@ -942,11 +942,11 @@ index f0ce6bc..e76d46b 100644
 +      // Already has a CCM prefix (e.g. "unstable/master:date") — pass through as-is.
 +      return SCYLLA_VERSION;
 +    }
-+    // Use local tarball when available, otherwise download from S3.
++    // Use local tarball when available; otherwise only release-repository versions use S3.
 +    if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
 +      return SCYLLA_VERSION;
 +    }
-+    return "release:" + SCYLLA_VERSION;
++    return SCYLLA_VERSION.matches("\\d+(\\.\\d+)+([-.]?(rc|alpha|beta)\\d+)?") ? "release:" + SCYLLA_VERSION : SCYLLA_VERSION;
 +  }
 +
    private String getCcmVersionString(Version version) {

--- a/versions/scylla/4.18.1.0/patch
+++ b/versions/scylla/4.18.1.0/patch
@@ -457,12 +457,12 @@ index 7b4d28cedf..88fe5b9809 100644
 +      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
 +      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
 +      // bare version string so CCM resolves via packages_from_env() and uses the local file.
-+      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
-+      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      // When not set (e.g. GH Actions CI), prepend "release:" only for release-repository
++      // versions so CCM downloads them from S3 and dev labels stay unprefixed.
 +      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
 +        return versionString;
 +      }
-+      return "release:" + versionString;
++      return versionString.matches("\\d+(\\.\\d+)+([-.]?(rc|alpha|beta)\\d+)?") ? "release:" + versionString : versionString;
      }
      // for 4.0 pre-releases, the CCM version string needs to be "4.0-alpha1" or "4.0-alpha2"
      // Version.toString() always adds a patch value, even if it's not specified when parsing.
@@ -799,4 +799,3 @@ index c6e9091220..18dbc060ba 100644
      assertThat(stream.get()).hasSize(10);
    }
  
-

--- a/versions/scylla/4.19.0.9/patch
+++ b/versions/scylla/4.19.0.9/patch
@@ -215,12 +215,12 @@ index e7b2b4e4a0..8fbbed8d95 100644
 +      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
 +      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
 +      // bare version string so CCM resolves via packages_from_env() and uses the local file.
-+      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
-+      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      // When not set (e.g. GH Actions CI), prepend "release:" only for release-repository
++      // versions so CCM downloads them from S3 and dev labels stay unprefixed.
 +      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
 +        return versionString;
 +      }
-+      return "release:" + versionString;
++      return versionString.matches("\\d+(\\.\\d+)+([-.]?(rc|alpha|beta)\\d+)?") ? "release:" + versionString : versionString;
      }
      // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
      // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when

--- a/versions/scylla/4.19.2.0/patch
+++ b/versions/scylla/4.19.2.0/patch
@@ -216,12 +216,12 @@ index e7b2b4e4a0..8fbbed8d95 100644
 +      // When SCYLLA_UNIFIED_PACKAGE is set, a local ScyllaDB tarball is available (e.g.
 +      // Jenkins pre-downloads dev/unreleased builds that are not published to S3). Pass the
 +      // bare version string so CCM resolves via packages_from_env() and uses the local file.
-+      // When not set (e.g. GH Actions CI), prepend "release:" so CCM downloads the published
-+      // release from S3. This avoids "release:<dev-version>" S3 lookup failures on Jenkins.
++      // When not set (e.g. GH Actions CI), prepend "release:" only for release-repository
++      // versions so CCM downloads them from S3 and dev labels stay unprefixed.
 +      if (System.getenv("SCYLLA_UNIFIED_PACKAGE") != null) {
 +        return versionString;
 +      }
-+      return "release:" + versionString;
++      return versionString.matches("\\d+(\\.\\d+)+([-.]?(rc|alpha|beta)\\d+)?") ? "release:" + versionString : versionString;
      }
      // for 4.0 or 5.0 pre-releases, the CCM version string needs to be "4.0-alpha1", "4.0-alpha2" or
      // "5.0-beta1" Version.toString() always adds a patch value, even if it's not specified when


### PR DESCRIPTION
## Summary
- Add a release-repository version predicate before synthesizing `release:` for Apache driver matrix runs.
- Preserve dev build labels such as `2026.2.0~dev` and `2026.2.0-dev` instead of treating them as release repository versions.
- Apply the same predicate to Java driver patch snippets that can also synthesize CCM `release:` values, while keeping release/RC forms prefixed.

Fixes #123

## Tests
- `python3 -m pytest`
- `git diff --check`