### PR TITLE
ci: add scylla 3.11.5.16 matrix patch

### DIFF
--- a/versions/scylla/3.11.5.16/ignore.yaml
+++ b/versions/scylla/3.11.5.16/ignore.yaml
@@ -1,0 +1,23 @@
+tests:
+  # test count on tracing which its content is different in scylla, should be skipped on scylla
+  # (should_create_tombstone_when_null_value_on_bound_statement)
+  - PreparedStatementTest
+
+  # disable because now CCM uses different ip address and port for the JMX
+  - CCMBridgeTest
+
+  # using 2 node cluster, and stopping one, isn't supported by scylla since raft
+  # (should_receive_changes_made_while_control_connection_is_down_on_reconnect)
+  - SchemaChangesCCTest
+
+  # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
+  # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
+  - ReconnectionTest
+
+  # scylla-ccm no longer supports --sni-proxy option
+  - ScyllaSniProxyTest
+
+  # node stop/start sequence causes Scylla to fail to open its binary port within the 5-minute
+  # CCM timeout, likely due to timing differences vs Cassandra in this driver version
+  # (should_call_onAdd_with_bootstrap_stop_start)
+  - NodeRefreshDebouncerTest

--- a/versions/scylla/3.11.5.16/patch
+++ b/versions/scylla/3.11.5.16/patch
@@ -1,0 +1,134 @@
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+index 1fe0fb50f3..d2360664c1 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+@@ -207,11 +207,12 @@ public class CCMBridge implements CCMAccess {
+       installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
+     } else if (inputScyllaVersion != null && !inputScyllaVersion.trim().isEmpty()) {
+       installArgs.add(" --scylla ");
+-      if (isVersionNumber(inputScyllaVersion)) {
+-        installArgs.add("-v release:" + inputScyllaVersion);
+-      } else {
+-        installArgs.add("-v " + inputScyllaVersion);
+-      }
++      // Use release: prefix in GitHub Actions (no local tarball); bare version in Jenkins
++      // where SCYLLA_UNIFIED_PACKAGE points CCM to a local tarball via packages_from_env().
++      String scyllaCcmVersion = System.getenv("SCYLLA_UNIFIED_PACKAGE") != null
++          ? inputScyllaVersion : "release:" + inputScyllaVersion;
++      installArgs.add("-v " + scyllaCcmVersion);
++
+       // Detect Scylla Enterprise - it should start with
+       // a 4-digit year.
+       if (inputScyllaVersion.matches("\\d{4}\\..*")) {
+@@ -480,10 +481,14 @@ public class CCMBridge implements CCMAccess {
+ 
+   @Override
+   public InetSocketAddress jmxAddressOfNode(int n) {
++    // For dynamically added nodes (via add()), jmxPorts[] may not have an entry since it is
++    // sized only for nodes declared at cluster-creation time. Fall back to the same deterministic
++    // formula used in add().
++    int port = (n - 1 < jmxPorts.length) ? jmxPorts[n - 1] : (7000 + n * 100);
+     if (GLOBAL_SCYLLA_VERSION_NUMBER != null) {
+-      return new InetSocketAddress(ipOfNode(n), jmxPorts[n - 1]);
++      return new InetSocketAddress(ipOfNode(n), port);
+     } else {
+-      return new InetSocketAddress("localhost", jmxPorts[n - 1]);
++      return new InetSocketAddress("localhost", port);
+     }
+   }
+ 
+@@ -733,23 +738,25 @@ public class CCMBridge implements CCMAccess {
+   public void add(int dc, int n) {
+     logger.debug(
+         String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
+-    String thriftItf = ipOfNode(n) + ":" + thriftPort;
+     String storageItf = ipOfNode(n) + ":" + storagePort;
+     String binaryItf = ipOfNode(n) + ":" + binaryPort;
+     String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
++    // Use a deterministic JMX port formula to avoid TOCTOU races from findAvailablePort()
++    // and to match the fallback in jmxAddressOfNode() for dynamically added nodes (jmxPorts[]
++    // is sized only for nodes declared at cluster-creation time).
++    int jmxPort = 7000 + n * 100;
+     execute(
+         CCM_COMMAND
+-            + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b"
++            + " add node%d -d dc%s -i %s%d -l %s --binary-itf %s -j %d -r %s -s -b"
+             + (isDSE ? " --dse" : "")
+             + (isScylla ? " --scylla" : ""),
+         n,
+         dc,
+         ipPrefix,
+         n,
+-        thriftItf,
+         storageItf,
+         binaryItf,
+-        TestUtils.findAvailablePort(),
++        jmxPort,
+         remoteLogItf);
+   }
+ 
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+index c8627f1d0b..dc432998f6 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+@@ -1023,7 +1023,10 @@ public class CCMTestsSupport {
+       try {
+         keyspace = TestUtils.generateIdentifier("ks_");
+         LOGGER.debug("Using keyspace " + keyspace);
+-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
++        boolean isScylla = CCMBridge.getGlobalScyllaVersion() != null;
++        session.execute(
++            String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1)
++                + (isScylla ? " AND tablets = {'enabled': false}" : ""));
+         useKeyspace(keyspace);
+       } catch (Exception e) {
+         errorOut();
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+index ea75f84544..ea70e9081a 100644
+--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
+ import org.testng.annotations.AfterMethod;
+ import org.testng.annotations.Test;
+ 
+-@CCMConfig(dirtiesContext = true)
++@CCMConfig(
++    dirtiesContext = true,
++    jvmArgs = {"--smp", "1", "--max-networking-io-control-blocks", "15000"})
+ public class SessionStressTest extends CCMTestsSupport {
+ 
+   private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+@@ -115,6 +115,7 @@ public class WarningsTest extends CCMTestsSupport {
+ 
+   @Test(groups = "isolated")
++  @ScyllaSkip /* @IntegrationTestDisabledScyllaFailure */
+   @CassandraVersion("3.0.0")
+   public void should_execute_query_and_not_log_server_side_warnings() throws Exception {
+     // Get the system property value for disabling logging server side warnings
+     final String disabledLogFlag =
+diff --git a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java
+--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java
++++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LWTLoadBalancingIT.java
+@@ -61,8 +61,8 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
+     Session session = session();
+ 
+     SimpleStatement simpleSelect =
+-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 1, 0);
++        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
+     simpleSelect.setConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
+ 
+     PreparedStatement preparedSelect = session.prepare(simpleSelect);
+     BoundStatement boundSelect = preparedSelect.bind(1, 0);
+@@ -91,8 +91,8 @@ public class LWTLoadBalancingIT extends CCMTestsSupport {
+     Session session = session();
+ 
+     SimpleStatement simpleSelect =
+-        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?", 2, 0);
++        new SimpleStatement("SELECT * FROM test_lwt WHERE pk = ? AND ck = ?");
+     simpleSelect.setConsistencyLevel(ConsistencyLevel.SERIAL);
+ 
+     PreparedStatement preparedSelect = session.prepare(simpleSelect);
+     BoundStatement boundSelect = preparedSelect.bind(2, 0);


### PR DESCRIPTION
## Summary

Add a dedicated `versions/scylla/3.11.5.16/` directory so the matrix no longer falls back to the stale `3.11.5.15` patch.

The new patch keeps the adaptations still needed by `3.11.5.16` and intentionally omits the `ShardAwarenessTest` hunk because that change is already present in the `3.11.5.16` driver tag.

Fixes #178
Part of #177

## Testing

- `python - <<'PY' ... load_ignore_tests(Path('versions/scylla/3.11.5.16/ignore.yaml')) ... PY`
- `git -C /tmp/java-driver-3.11.5.16 apply --check versions/scylla/3.11.5.16/patch`
- `patch -d /tmp/java-driver-3.11.5.16 -p1 --dry-run -i versions/scylla/3.11.5.16/patch`
- `pytest -q tests/test_ignore_yaml.py`