### PR TITLE
ci: skip WarningsTest for scylla 3.11.4.0

### DIFF
--- a/versions/scylla/3.11.4.0/ignore.yaml
+++ b/versions/scylla/3.11.4.0/ignore.yaml
@@ -10,6 +10,10 @@ tests:
   # (should_receive_changes_made_while_control_connection_is_down_on_reconnect)
   - SchemaChangesCCTest
 
+  # Scylla does not return the Cassandra warning expected by this class
+  # (should_execute_query_and_not_log_server_side_warnings)
+  - WarningsTest
+
   # as ScyllaSkip mark doesn't seem to function correctly (skipping, but then failing the test again anyway)
   # the class is disabled due to unsupported options used for Scylla (should_keep_reconnecting_on_authentication_error)
   - ReconnectionTest


### PR DESCRIPTION
## Summary

Exclude `WarningsTest` for `versions/scylla/3.11.4.0`.

`WarningsTest.should_execute_query_and_not_log_server_side_warnings` expects the Cassandra warning `Aggregation query used without partition key` for `SELECT count(*) FROM foo`. Current Scylla does not return that warning, so the test fails with an empty warnings list. Older 3.x matrix configurations already skip `WarningsTest` for Scylla-incompatible behavior; this applies the same policy to `3.11.4.0`.

Fixes #179
Part of #177

## Testing

- `python - <<'PY' ... assert 'WarningsTest' in load_ignore_tests(Path('versions/scylla/3.11.4.0/ignore.yaml')) ... PY`
- `pytest -q tests/test_ignore_yaml.py`