### PR TITLE
ci: refresh Java environment per driver checkout

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,6 +64,7 @@ jobs:
           target="${SCYLLA_VERSION:-LATEST}"
           filters=""
           fallback_repo=""
+          fallback_filters=""
           needs_resolution=true
 
           # get-version treats dots as version-component separators. The regex components below
@@ -72,7 +73,8 @@ jobs:
           # LAST.LAST.LAST = newest patch in the newest minor of the newest calendar major,
           # LAST.LAST.LAST-1 = previous patch in that same minor, LAST.1.LAST = newest LTS
           # patch in the newest calendar major, and LAST-1.1.LAST = newest LTS patch in the
-          # previous calendar major.
+          # previous calendar major. PRIOR falls back to LAST.LAST-1.LAST when the newest minor
+          # has only one patch release.
           case "$target" in
             LTS-LATEST)
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.1.LAST'
@@ -80,12 +82,14 @@ jobs:
             LTS-PRIOR)
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1.1.LAST'
               fallback_repo="scylladb/scylla-enterprise"
+              fallback_filters="$filters"
               ;;
             LATEST)
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
               ;;
             PRIOR)
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              fallback_filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST-1.LAST'
               ;;
             *)
               needs_resolution=false
@@ -98,6 +102,7 @@ jobs:
             echo "repo=scylladb/scylla"
             echo "fallback_repo=$fallback_repo"
             echo "filters=$filters"
+            echo "fallback_filters=$fallback_filters"
           } >> "$GITHUB_OUTPUT"
 
       - name: Resolve Scylla version
@@ -111,13 +116,13 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Resolve Scylla version fallback
-        if: ${{ steps.scylla-query.outputs.fallback_repo != '' && (steps.get-scylla-version.outputs.versions == '' || steps.get-scylla-version.outputs.versions == '[]') }}
+        if: ${{ steps.scylla-query.outputs.fallback_filters != '' && (steps.get-scylla-version.outputs.versions == '' || steps.get-scylla-version.outputs.versions == '[]') }}
         id: get-scylla-version-fallback
         uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
         with:
           source: dockerhub-imagetag
-          repo: ${{ steps.scylla-query.outputs.fallback_repo }}
-          filters: ${{ steps.scylla-query.outputs.filters }}
+          repo: ${{ steps.scylla-query.outputs.fallback_repo || steps.scylla-query.outputs.repo }}
+          filters: ${{ steps.scylla-query.outputs.fallback_filters }}
           github-token: ${{ github.token }}
 
       - name: Normalize inputs

--- a/run.py
+++ b/run.py
@@ -150,7 +150,7 @@ class Run:
         ignore_file_path = self.version_folder / "ignore.yaml"
         return load_ignore_tests(ignore_file_path)
 
-    @cached_property
+    @property
     def environment(self):
         result = {}
         result.update(os.environ)

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -97,3 +97,15 @@ def test_integration_workflow_uploads_reports_after_failures():
     assert "driver/integration-tests/target/failsafe-reports/" in reports["with"]["path"]
     assert "driver/driver-core/target/surefire-reports/" in reports["with"]["path"]
     assert "~/.ccm/*/node*/logs/**" in ccm_logs["with"]["path"]
+
+
+def test_integration_workflow_prior_scylla_version_has_fallback():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text())
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    select = next(step for step in steps if step.get("name") == "Select Scylla version query")
+    fallback = next(step for step in steps if step.get("name") == "Resolve Scylla version fallback")
+
+    assert "LAST.LAST.LAST-1" in select["run"]
+    assert "LAST.LAST-1.LAST" in select["run"]
+    assert "fallback_filters" in fallback["if"]
+    assert "fallback_filters" in fallback["with"]["filters"]

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -221,6 +221,29 @@ def test_environment_uses_java_11_for_add_exports_jvm_config(monkeypatch, tmp_pa
     assert runner.environment["JAVA_HOME"] == str(java_home_11)
 
 
+def test_environment_rechecks_jvm_config_between_checkouts(monkeypatch, tmp_path):
+    java_home_8 = tmp_path / "jdk-8"
+    java_home_11 = tmp_path / "jdk-11"
+    java_home_8.mkdir()
+    java_home_11.mkdir()
+    monkeypatch.setenv("JAVA_HOME", str(java_home_8))
+    monkeypatch.setenv("JAVA_HOME_11_X64", str(java_home_11))
+    runner = make_runner(tmp_path)
+
+    assert runner.environment["JAVA_HOME"] == str(java_home_8)
+
+    jvm_config = runner._java_driver_git / ".mvn" / "jvm.config"
+    jvm_config.parent.mkdir()
+    jvm_config.write_text(
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED\n",
+        encoding="utf-8",
+    )
+    assert runner.environment["JAVA_HOME"] == str(java_home_11)
+
+    jvm_config.unlink()
+    assert runner.environment["JAVA_HOME"] == str(java_home_8)
+
+
 def test_run_command_invokes_subprocess_without_shell(monkeypatch, tmp_path):
     runner = make_runner(tmp_path, checkout_ref="feature/ref; echo unsafe")
     captured = {}


### PR DESCRIPTION
## Summary

Recompute `Run.environment` on each command instead of caching it for the lifetime of a `Run` object.

The runner selects Java 11 when the checked-out driver has `.mvn/jvm.config` with `--add-exports`. Caching the environment means Java selection can be computed before the target checkout exposes or removes `.mvn/jvm.config`, then leak into later Maven invocations. This caused both observed failures:

- `4.19.2.0` reused Java 8 and failed on `--add-exports`.
- `4.19.0.9` reused Java 11 and failed compiling Java 8-targeted `guava-shaded` sources.

Fixes #180
Fixes #181
Related #170
Part of #177

## Testing

- `pytest -q tests/test_run_command.py`
- `pytest -q`