### PR TITLE
Ignore PeersV2NodeRefreshIT for Scylla 4.19.2.0

### DIFF
--- a/versions/scylla/4.19.2.0/ignore.yaml
+++ b/versions/scylla/4.19.2.0/ignore.yaml
@@ -6,3 +6,9 @@ tests:
   - ClientRoutesIT
   # Event-driven config reload is flaky in the matrix runner.
   - DriverExecutionProfileReloadIT
+  # PeersV2NodeRefreshIT fails with BindNodeException on hardcoded port 49152 when
+  # the port is still occupied from a prior test run in the same CI job.
+  # Root cause: NodePerPortResolver missing release() override + shared static singleton.
+  # Fix: https://github.com/scylladb/java-simulacron/pull/5 (issue #4)
+  # TODO: remove this entry once the simulacron fix is released and picked up in the driver pom.xml
+  - PeersV2NodeRefreshIT


### PR DESCRIPTION
Add PeersV2NodeRefreshIT to the Scylla 4.19.2.0 ignore list.

The test fails intermittently with BindNodeException on hardcoded port 49152, same as the already ignored Apache 4.19.x variants. This was seen in Jenkins java-driver-matrix-test #2066.

Validation:
- pytest -q